### PR TITLE
Adapt the convertor to tensorrt backend 

### DIFF
--- a/fluid_onnx/ops.py
+++ b/fluid_onnx/ops.py
@@ -239,7 +239,7 @@ def dropout_op(operator, block):
             broadcast=1)
         nodes = (dropout_node, constant_node, mul_node)
     else:
-        scale_op = make_node(
+        scale_node = make_node(
             'Scale',
             inputs=scale_input,
             outputs=outputs['Out'],
@@ -428,7 +428,7 @@ def mul_op(operator, block):
             value=make_tensor(
                 name=output_shape_name[0],
                 data_type=TensorProto.INT64,
-                dims=(1, len(out_shape)),
+                dims=(len(out_shape), ),
                 vals=out_shape))
         output_node = make_node(
             'Reshape',

--- a/fluid_onnx/ops.py
+++ b/fluid_onnx/ops.py
@@ -316,8 +316,16 @@ def instancenormalization_op():
     pass
 
 
-def lrn_op():
-    pass
+def lrn_op(operator, block):
+    inputs, attrs, outputs = op_io_info(operator)
+    return make_node(
+        'LRN',
+        inputs=inputs['X'],
+        outputs=outputs['Out'],
+        alpha=attrs['alpha'],
+        beta=attrs['beta'],
+        bias=attrs['k'],
+        size=attrs['n'])
 
 
 def lstm_op():
@@ -690,7 +698,7 @@ node_maker = {
     'hard_sigmoid': 'HardSigmoid',  # Caffe2 error
     # 'Hardmax', NEEDS ATTENTION.
     # 'InstanceNormalization', NEEDS ATTENTION.
-    '': 'LRN',
+    'lrn': lrn_op,
     '': 'LSTM',
     '': 'LeakyRelu',
     '': 'Less',

--- a/fluid_onnx/variables.py
+++ b/fluid_onnx/variables.py
@@ -15,6 +15,7 @@
 import numpy as np
 from onnx import helper, onnx_pb2, TensorProto
 import paddle.fluid.core as core
+from paddle.fluid.executor import fetch_var
 
 
 def paddle_variable_to_onnx_tensor(paddle_var_name, block):
@@ -32,6 +33,18 @@ def paddle_onnx_shape(paddle_shape):
     onnx_shape = np.array(list(paddle_shape))
     onnx_shape[onnx_shape < 0] = 0
     return tuple(onnx_shape)
+
+
+def paddle_onnx_weight(var, scope):
+    data = fetch_var(var.name, scope)
+    weight = helper.make_tensor(
+        name=var.name,
+        dims=var.shape,
+        data_type=PADDLE_TO_ONNX_DTYPE[var.dtype],
+        vals=data.flatten().tolist())
+    value_info = helper.make_tensor_value_info(
+        var.name, PADDLE_TO_ONNX_DTYPE[var.dtype], var.shape)
+    return weight, value_info
 
 
 PADDLE_TO_ONNX_DTYPE = {

--- a/fluid_to_onnx.py
+++ b/fluid_to_onnx.py
@@ -65,7 +65,8 @@ def convert(args):
             if var_name not in ['feed', 'fetch'] and var.persistable:
                 weight, val_info = paddle_onnx_weight(
                     var=var, scope=inference_scope)
-                weights.append(weight), weights_value_info.append(val_info)
+                weights.append(weight)
+                weights_value_info.append(val_info)
 
         # Create inputs
         inputs = [
@@ -96,7 +97,7 @@ def convert(args):
         fetch_target_names = [
             fetch_target.name for fetch_target in fetch_targets
         ]
-        # Get the new names for outputs if they've renamed in nodes' making
+        # Get the new names for outputs if they've been renamed in nodes' making
         renamed_outputs = op_io_info.get_all_renamed_outputs()
         fetch_target_names = [
             name if name not in renamed_outputs else renamed_outputs[name]

--- a/fluid_to_onnx.py
+++ b/fluid_to_onnx.py
@@ -58,14 +58,14 @@ def convert(args):
          fetch_targets] = fluid.io.load_inference_model(args.fluid_model, exe)
 
         # Load parameters
-        weights, value_info = [], []
+        weights, weights_value_info = [], []
         global_block = inference_program.global_block()
         for var_name in global_block.vars:
             var = global_block.var(var_name)
             if var_name not in ['feed', 'fetch'] and var.persistable:
                 weight, val_info = paddle_onnx_weight(
                     var=var, scope=inference_scope)
-                weights.append(weight), value_info.append(val_info)
+                weights.append(weight), weights_value_info.append(val_info)
 
         # Create inputs
         inputs = [
@@ -113,7 +113,7 @@ def convert(args):
             nodes=onnx_nodes,
             name=model_name,
             initializer=weights,
-            inputs=inputs + value_info,
+            inputs=inputs + weights_value_info,
             outputs=outputs)
 
         # Make model

--- a/tests/op_test.py
+++ b/tests/op_test.py
@@ -213,10 +213,15 @@ class OpTest(unittest.TestCase):
             self.op.desc.infer_var_type(self.block.desc)
             self.op.desc.infer_shape(self.block.desc)
 
+            # A list containing outputs that wouldn't be used as outputs 
+            # of ONNX node
+            ignored_outputs = self.ignored_outputs if hasattr(
+                self, "ignored_outputs") else []
+
             # Construct a unique list of outputs to fetch.
             self.fetch_list = []
             for var_name, var in outputs.iteritems():
-                if var_name in self.outputs:
+                if var_name in self.outputs and var_name not in ignored_outputs:
                     if isinstance(var, list):
                         for v in var:
                             self.fetch_list.append(v)

--- a/tests/test_lrn_op.py
+++ b/tests/test_lrn_op.py
@@ -1,0 +1,33 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest
+
+
+class TestLRNOp(OpTest):
+    def setUp(self):
+        self.op_type = 'lrn'
+        self.inputs = {'X': np.random.random((2, 3, 4, 5)).astype('float32')}
+        self.attrs = {'n': 5, 'k': 2.0, 'alpha': 0.0001, 'beta': 0.75}
+        self.outputs = {'Out': np.zeros((1, 1)), 'MidOut': np.zeros((1, 1))}
+        self.ignored_outputs = ['MidOut']
+
+    def test_check_output(self):
+        self.check_output(decimal=4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mul_op.py
+++ b/tests/test_mul_op.py
@@ -22,13 +22,10 @@ class TestMulOp(OpTest):
         self.op_type = 'mul'
         self.inputs = {
             'X': np.random.random((15, 4, 12, 10)).astype('float32'),
-            'Y': np.random.random((4, 30, 8, 2, 9)).astype('float32')
+            'Y': np.random.random((30, 4, 4, 9)).astype('float32')
         }
         self.attrs = {'x_num_col_dims': 2, 'y_num_col_dims': 2}
-        result = np.dot(self.inputs['X'].reshape(15 * 4, 12 * 10),
-                        self.inputs['Y'].reshape(4 * 30, 8 * 2 * 9))
-        result = result.reshape(15, 4, 8, 2, 9)
-        self.outputs = {'Out': result}
+        self.outputs = {'Out': np.zeros((1, 1))}
 
     def test_check_output(self):
         self.check_output()


### PR DESCRIPTION
Resolve #46 

The [TensorRT backend](https://github.com/onnx/onnx-tensorrt) for onnx only supports `onnx==1.0.1` right now, while we were carrying out experiments on master branch of ONNX and caffe2 backend. Hence, we need to make some adaptions to enable the converted models running with TensorRT backend. 

Now the conversion's correctness of all the current supported models has been validated on TensorRT, including: 

- fit_a_line
- recognize_digits
- VGG16 & ResNet50
- MobileNet
- SE_ResNeXt
