### PR TITLE
Add inception-v4 to supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ We aim to at least support all the models from our model bank. During our prelim
 - [VGG16 & ResNet50](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/tests/book/test_image_classification.py)
 - [MobileNet](https://github.com/PaddlePaddle/models/blob/develop/fluid/image_classification/mobilenet.py)
 - [SE_ResNeXt](https://github.com/PaddlePaddle/models/blob/develop/fluid/image_classification/se_resnext.py)
+- [Inception-v4](https://github.com/PaddlePaddle/models/blob/develop/fluid/image_classification/inception_v4.py)
 
 
 ## Got feedback or issues?

--- a/tests/test_concat_op.py
+++ b/tests/test_concat_op.py
@@ -35,7 +35,7 @@ class TestConcatOp(OpTest):
         self.axis = 1
 
 
-class TestConcatOp2(OpTest):
+class TestConcatOp2(TestConcatOp):
     def init_test_data(self):
         self.x0 = np.random.random((2, 3, 4, 5)).astype('float32')
         self.x1 = np.random.random((2, 3, 4, 5)).astype('float32')


### PR DESCRIPTION
```
-----------  Configuration Arguments -----------
a: 0.0
b: 1.0
backend: caffe2
batch_size: 10
expected_decimal: 5
fluid_model: extras/inception_v4.inference.model/
onnx_model: inception_v4.onnx
------------------------------------------------
Inference results for fluid model:
[array([[0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       ...,
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415]], dtype=float32)]


Inference results for ONNX model:
Outputs(_0=array([[0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       ...,
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415],
       [0.0096415, 0.0096415, 0.0096415, ..., 0.0096415, 0.0096415,
        0.0096415]], dtype=float32))


The exported model achieves 5-decimal precision.
```

On flowers dataset. Not validated on TensorRT backend for its `Concat` op implementation doesn't support inputs with different shape