### PR TITLE
Some adaptions to onnx-1.2.2

### DIFF
--- a/fluid/utils.py
+++ b/fluid/utils.py
@@ -37,7 +37,8 @@ class OpIOsInfo():
         """
 
         for in_name in self.inputs:
-            if self.inputs[in_name][0] in self._all_renamed_outputs:
+            if (len(self.inputs[in_name]) > 0) and (
+                    self.inputs[in_name][0] in self._all_renamed_outputs):
                 self.inputs[in_name][0] = self._all_renamed_outputs[self.inputs[
                     in_name][0]]
 
@@ -48,7 +49,8 @@ class OpIOsInfo():
 
         input_args = flatten(self.inputs.values())
         for out_name in self.outputs:
-            if self.outputs[out_name][0] in input_args:
+            if len(self.outputs[out_name]) > 0 and self.outputs[out_name][
+                    0] in input_args:
                 new_name = self._get_new_name(self.outputs[out_name][0])
                 self._all_renamed_outputs[self.outputs[out_name][0]] = new_name
                 self.outputs[out_name][0] = new_name

--- a/fluid_onnx/ops.py
+++ b/fluid_onnx/ops.py
@@ -433,13 +433,23 @@ def pool2d_op(operator, block):
     inputs, attrs, outputs = op_io_info(operator)
     if attrs['global_pooling'] is False:
         op_type = {'max': 'MaxPool', 'avg': 'AveragePool'}
+
+        pads = attrs['paddings']
+        if attrs['ceil_mode'] is True:
+            pads += [
+                attrs['paddings'][0] + attrs['strides'][0] - 1,
+                attrs['paddings'][1] + attrs['strides'][1] - 1
+            ]
+        else:
+            pads += attrs['paddings']
+
         pool2d = make_node(
             op_type[attrs['pooling_type']],
             inputs=inputs['X'],
             outputs=outputs['Out'],
             kernel_shape=attrs['ksize'],
             strides=attrs['strides'],
-            pads=attrs['paddings'] + attrs['paddings'], )
+            pads=pads, )
     else:
         op_type = {'max': 'GlobalMaxPool', 'avg': 'GlobalAveragePool'}
         pool2d = make_node(

--- a/fluid_onnx/ops.py
+++ b/fluid_onnx/ops.py
@@ -90,29 +90,19 @@ def batch_norm_op(operator, block):
     if len(x_shape) == 2:
         new_shape = [0, x_shape[1], 1, 1]
         reshaped_x = [inputs['X'][0] + '@reshape_0']
-        if __onnx_ver__ == '1.0.1':
-            reshape_node = make_node(
-                'Reshape',
-                inputs=inputs['X'],
-                shape=new_shape,
-                outputs=reshaped_x)
-        else:
-            new_shape_name = [inputs['X'][0] + '@shape_tensor_0']
-            new_shape_node = make_node(
-                'Constant',
-                inputs=[],
-                outputs=new_shape_name,
-                value=make_tensor(
-                    name=new_shape_name[0],
-                    data_type=TensorProto.INT64,
-                    dims=(4, ),
-                    vals=new_shape))
-            reshape_node = make_node(
-                'Reshape',
-                inputs=inputs['X'] + new_shape_name,
-                outputs=reshaped_x)
-            nodes = (new_shape_node, )
-        nodes += (reshape_node, )
+        new_shape_name = [inputs['X'][0] + '@shape_tensor_0']
+        new_shape_node = make_node(
+            'Constant',
+            inputs=[],
+            outputs=new_shape_name,
+            value=make_tensor(
+                name=new_shape_name[0],
+                data_type=TensorProto.INT64,
+                dims=(4, ),
+                vals=new_shape))
+        reshape_node = make_node(
+            'Reshape', inputs=inputs['X'] + new_shape_name, outputs=reshaped_x)
+        nodes += (new_shape_node, reshape_node)
     else:
         reshaped_x = inputs['X']
 
@@ -121,10 +111,6 @@ def batch_norm_op(operator, block):
         'epsilon': attrs['epsilon'],
         'momentum': attrs['momentum']
     }
-    # In v1.0.1, need to set input(Mean) and input(Variance) to be consumed 
-    # explicitly. 
-    if __onnx_ver__ == '1.0.1':
-        kwargs['consumed_inputs'] = [0, 0, 0, 1, 1]
 
     bn_node = make_node(
         'BatchNormalization',
@@ -138,6 +124,7 @@ def batch_norm_op(operator, block):
 
 def cast_op(operator, block):
     inputs, attrs, outputs = op_io_info(operator)
+    # bug in onnx-1.2.2
     return make_node(
         'Cast',
         inputs=inputs['X'],
@@ -229,35 +216,15 @@ def dropout_op(operator, block):
         'Dropout',
         inputs=inputs['X'],
         outputs=scale_input + outputs['Mask'],
-        is_test=attrs['is_test'],
-        ratio=attrs['dropout_prob'])
+        ratio=attrs['dropout_prob'] if not attrs['is_test'] else 0.0)
 
     ## Fluid and ONNX use different dropout formula
-    # ONNX 1.0.1 doesn't support Scale op
-    if __onnx_ver__ == '1.0.1':
-        scale_val = [outputs['Out'][0] + '@scale']
-        constant_node = make_node(
-            'Constant',
-            inputs=[],
-            outputs=scale_val,
-            value=make_tensor(
-                name=scale_val[0],
-                dims=(),
-                data_type=TensorProto.FLOAT,
-                vals=[1.0 - attrs['dropout_prob']]))
-        mul_node = make_node(
-            'Mul',
-            inputs=scale_input + scale_val,
-            outputs=outputs['Out'],
-            broadcast=1)
-        nodes = (dropout_node, constant_node, mul_node)
-    else:
-        scale_node = make_node(
-            'Scale',
-            inputs=scale_input,
-            outputs=outputs['Out'],
-            scale=1.0 - attrs['dropout_prob'])
-        nodes = (dropout_node, scale_node)
+    scale_node = make_node(
+        'Scale',
+        inputs=scale_input,
+        outputs=outputs['Out'],
+        scale=1.0 - attrs['dropout_prob'])
+    nodes = (dropout_node, scale_node)
     return nodes
 
 
@@ -269,13 +236,8 @@ def elementwise_ops(op_type, operator, block):
     inputs, attrs, outputs = op_io_info(operator)
     rank_x = len(block.vars[get_old_name(inputs['X'][0])].shape)
     rank_y = len(block.vars[get_old_name(inputs['Y'][0])].shape)
-    axis = rank_x - rank_y if attrs['axis'] == -1 else attrs['axis']
     return make_node(
-        op_type,
-        inputs=inputs['X'] + inputs['Y'],
-        outputs=outputs['Out'],
-        axis=axis,
-        broadcast=1)
+        op_type, inputs=inputs['X'] + inputs['Y'], outputs=outputs['Out'])
 
 
 def elu_op(operator, block):
@@ -399,38 +361,16 @@ def mul_op(operator, block):
     x_flat_out = [inputs['X'][0] + '@flatten_0']
     y_flat_out = [inputs['Y'][0] + '@flatten_0']
 
-    # Because in TensorRT backend, Flatten op only accepts input tensor with 
-    # dimension 3, here we use Reshape op to flatten the input tensor when 
-    # ONNX is v1.0.1. 
-    if __onnx_ver__ == '1.0.1':
-        # In v1.0.1, shape is the attribute of Reshape op, not an input tensor.
-        flatten_x_node = make_node(
-            'Reshape',
-            inputs=inputs['X'],
-            outputs=x_flat_out,
-            shape=[
-                np.prod(x_shape[:x_num_col_dims]),
-                np.prod(x_shape[x_num_col_dims:])
-            ])
-        flatten_y_node = make_node(
-            'Reshape',
-            inputs=inputs['Y'],
-            outputs=y_flat_out,
-            shape=[
-                np.prod(y_shape[:y_num_col_dims]),
-                np.prod(y_shape[y_num_col_dims:])
-            ])
-    else:
-        flatten_x_node = make_node(
-            'Flatten',
-            inputs=inputs['X'],
-            outputs=x_flat_out,
-            axis=attrs['x_num_col_dims'])
-        flatten_y_node = make_node(
-            'Flatten',
-            inputs=inputs['Y'],
-            outputs=y_flat_out,
-            axis=attrs['y_num_col_dims'])
+    flatten_x_node = make_node(
+        'Flatten',
+        inputs=inputs['X'],
+        outputs=x_flat_out,
+        axis=attrs['x_num_col_dims'])
+    flatten_y_node = make_node(
+        'Flatten',
+        inputs=inputs['Y'],
+        outputs=y_flat_out,
+        axis=attrs['y_num_col_dims'])
 
     # Mat mul 
     matmul_out = [outputs['Out'][0] + '@matmul_0']
@@ -439,29 +379,21 @@ def mul_op(operator, block):
 
     nodes = (flatten_x_node, flatten_y_node, matmul_node)
     # Reshpe output
-    if __onnx_ver__ == '1.0.1':
-        output_node = make_node(
-            'Reshape',
-            inputs=matmul_out,
-            shape=out_shape,
-            outputs=outputs['Out'])
-        nodes += (output_node, )
-    else:
-        output_shape_name = [outputs['Out'][0] + '@shape_0']
-        output_shape_node = make_node(
-            'Constant',
-            inputs=[],
-            outputs=output_shape_name,
-            value=make_tensor(
-                name=output_shape_name[0],
-                data_type=TensorProto.INT64,
-                dims=(len(out_shape), ),
-                vals=out_shape))
-        output_node = make_node(
-            'Reshape',
-            inputs=matmul_out + output_shape_name,
-            outputs=outputs['Out'])
-        nodes += (output_shape_node, output_node)
+    output_shape_name = [outputs['Out'][0] + '@shape_0']
+    output_shape_node = make_node(
+        'Constant',
+        inputs=[],
+        outputs=output_shape_name,
+        value=make_tensor(
+            name=output_shape_name[0],
+            data_type=TensorProto.INT64,
+            dims=(len(out_shape), ),
+            vals=out_shape))
+    output_node = make_node(
+        'Reshape',
+        inputs=matmul_out + output_shape_name,
+        outputs=outputs['Out'])
+    nodes += (output_shape_node, output_node)
 
     return nodes
 
@@ -548,25 +480,10 @@ def reduce_ops(op_type, operator, block):
 
     inputs, attrs, outputs = op_io_info(operator)
     rank = len(block.vars[get_old_name(inputs['X'][0])].shape)
-    dim = attrs['dim']
+    dim = attrs['dim'][0]
     axes = [dim if dim >= 0 else rank + dim]
-    reduce_out = [outputs['Out'][0] + '@reduce_0'] if attrs[
-        'reduce_all'] else outputs
     reduce_node = make_node(
-        op_type,
-        inputs=inputs['X'],
-        outputs=reduce_out,
-        axes=axes,
-        keepdims=attrs['keep_dim'])
-    if attrs['reduce_all'] is True:
-        axes = range(rank) if attrs['keep_dim'] else range(rank - 1)
-        reduce_all_node = make_node(
-            op_type,
-            inputs=reduce_out,
-            outputs=outputs,
-            axes=axes,
-            keepdims=attrs['keep_dim'])
-        return (reduce_node, reduce_all_node)
+        op_type, inputs=inputs['X'], outputs=outputs, keepdims=0, axes=axes)
     return reduce_node
 
 

--- a/fluid_onnx/variables.py
+++ b/fluid_onnx/variables.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import numpy as np
-from onnx import helper, onnx_pb2, TensorProto
+from onnx import helper, TensorProto
 import paddle.fluid.core as core
 from paddle.fluid.executor import fetch_var
 
@@ -48,17 +48,17 @@ def paddle_onnx_weight(var, scope):
 
 
 PADDLE_TO_ONNX_DTYPE = {
-    core.VarDesc.VarType.FP32: onnx_pb2.TensorProto.FLOAT,
-    core.VarDesc.VarType.FP64: onnx_pb2.TensorProto.DOUBLE,
-    # '': onnx_pb2.TensorProto.DOUBLE,
-    core.VarDesc.VarType.INT32: onnx_pb2.TensorProto.INT32,
-    core.VarDesc.VarType.INT16: onnx_pb2.TensorProto.INT16,
-    # '': onnx_pb2.TensorProto.INT8,
-    # '': onnx_pb2.TensorProto.UINT8,
-    core.VarDesc.VarType.INT16: onnx_pb2.TensorProto.UINT16,
-    core.VarDesc.VarType.INT64: onnx_pb2.TensorProto.INT64,
-    # '': onnx_pb2.TensorProto.STRING,
-    # '': onnx_pb2.TensorProto.COMPLEX64,
-    # '': onnx_pb2.TensorProto.COMPLEX128,
-    core.VarDesc.VarType.BOOL: onnx_pb2.TensorProto.BOOL
+    core.VarDesc.VarType.FP32: TensorProto.FLOAT,
+    core.VarDesc.VarType.FP64: TensorProto.DOUBLE,
+    # '': TensorProto.DOUBLE,
+    core.VarDesc.VarType.INT32: TensorProto.INT32,
+    core.VarDesc.VarType.INT16: TensorProto.INT16,
+    # '': TensorProto.INT8,
+    # '': TensorProto.UINT8,
+    core.VarDesc.VarType.INT16: TensorProto.UINT16,
+    core.VarDesc.VarType.INT64: TensorProto.INT64,
+    # '': TensorProto.STRING,
+    # '': TensorProto.COMPLEX64,
+    # '': TensorProto.COMPLEX128,
+    core.VarDesc.VarType.BOOL: TensorProto.BOOL
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 protobuf==3.5.1
 pytest-runner
-onnx==1.0.1
+onnx==1.2.2

--- a/tests/test_cast_op.py
+++ b/tests/test_cast_op.py
@@ -22,10 +22,10 @@ class TestCastOp(OpTest):
     def setUp(self):
         input = np.random.random((10, 10))
         self.inputs = {'X': input.astype('float32')}
-        self.outputs = {'Out': input.astype('float64')}
+        self.outputs = {'Out': input.astype('int32')}
         self.attrs = {
             'in_dtype': int(core.VarDesc.VarType.FP32),
-            'out_dtype': int(core.VarDesc.VarType.FP64)
+            'out_dtype': int(core.VarDesc.VarType.INT32)
         }
         self.op_type = 'cast'
 

--- a/tests/test_pool2d_op.py
+++ b/tests/test_pool2d_op.py
@@ -103,15 +103,24 @@ class TestPool2dOp3(TestPool2dOp):
     def init_pool_type(self):
         self.pool_type = 'max'
 
+    def init_ceil_mode(self):
+        self.ceil_mode = True
+
 
 class TestPool2dOp4(TestPool2dOp1):
     def init_pool_type(self):
         self.pool_type = 'max'
 
+    def init_ceil_mode(self):
+        self.ceil_mode = True
+
 
 class TestPool2dOp5(TestPool2dOp2):
     def init_pool_type(self):
         self.pool_type = 'max'
+
+    def init_ceil_mode(self):
+        self.ceil_mode = True
 
 
 if __name__ == '__main__':

--- a/tests/test_reduce_ops.py
+++ b/tests/test_reduce_ops.py
@@ -23,11 +23,7 @@ class TestReduceSumOp(OpTest):
         self.init_keep_dim()
         self.init_reduce_all()
         self.inputs = {'X': np.random.random((5, 6, 7, 8)).astype('float32')}
-        self.attrs = {
-            'dim': 2,
-            'keep_dim': self.keep_dim,
-            'reduce_all': self.reduce_all
-        }
+        self.attrs = {'dim': [2], }
         self.outputs = {'Out': np.zeros((1, 1))}
 
     def init_op_type(self):

--- a/tests/test_reshape_op.py
+++ b/tests/test_reshape_op.py
@@ -1,0 +1,72 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+
+from op_test import OpTest
+
+
+class TestReshapeOp(OpTest):
+    def setUp(self):
+        self.init_data()
+        self.op_type = "reshape"
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.attrs = {"shape": self.new_shape}
+        self.outputs = {"Out": np.zeros((1, 1)).astype('float32'), }
+
+    def init_data(self):
+        self.ori_shape = (2, 25)
+        self.new_shape = (5, 10)
+        self.infered_shape = (5, 10)
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestReshapeOpDimInfer1(TestReshapeOp):
+    def init_data(self):
+        self.ori_shape = (5, 10)
+        self.new_shape = (5, -1, 5)
+        self.infered_shape = (5, -1, 5)
+
+
+class TestReshapeOpDimInfer2(TestReshapeOp):
+    def init_data(self):
+        self.ori_shape = (2, 2, 6)
+        self.new_shape = (2, 0, 3, -1)
+        self.infered_shape = (2, 2, 3, -1)
+
+
+class TestReshapeOpWithInputShape(OpTest):
+    def setUp(self):
+        ori_shape = (6, 5)
+        new_shape = (0, -1, 5)
+        actual_shape = (2, 3, 5)
+
+        self.op_type = "reshape"
+        self.inputs = {
+            "X": np.random.random(ori_shape).astype("float32"),
+            "Shape": np.array(
+                actual_shape, dtype="int32")
+        }
+        self.attrs = {"shape": new_shape}
+        self.outputs = {"Out": self.inputs["X"].reshape(actual_shape), }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validate.py
+++ b/validate.py
@@ -57,7 +57,7 @@ def parse_args():
     parser.add_argument(
         "--backend",
         type=str,
-        choices=['caffe2', 'tensorrt'],
+        choices=['caffe2', 'tensorrt', 'tensorflow'],
         default='caffe2',
         help="The ONNX backend used for validation. (default: %(default)s)")
     args = parser.parse_args()
@@ -108,9 +108,12 @@ def validate(args):
     if args.backend == 'caffe2':
         from caffe2.python.onnx.backend import Caffe2Backend
         rep = Caffe2Backend.prepare(onnx_model, device='CPU')
-    else:
+    elif args.backend == 'tensorrt':
         import onnx_tensorrt.backend as backend
         rep = backend.prepare(onnx_model, device='CUDA:0')
+    else:
+        import onnx_tf.backend as backend
+        rep = backend.prepare(onnx_model, device='CPU')
     onnx_results = rep.run(inputs)
 
     print("Inference results for ONNX model:")


### PR DESCRIPTION
The unittest failures:

1. Infer data type error, which should result from the bug of onnx-1.2.2, including cast_op, compare_ops, logical_ops etc. Error in ```shape_inference.py```
```
RuntimeError: Inferred elem type differs from existing elem type.
```
when output data type doesn't exist in input data type.

2. ```elementwise_ops```. For these ops, onnx-1.2.2 doesn't hold the attribute `broadcast` any more, but the onnx backend (the latest caffe2, develop branch ) still does.

```
RuntimeError: [enforce fail at pow_op.h:98] A.dims() == B.dims(). 2 3 4 5 vs 4 5. Dimension mismatch - did you forget to set broadcast=1?Error from operator:
input: "X" input: "Y" output: "Out" name: "" type: "Pow" device_option { device_type: 0 cuda_gpu_id: 0 }
```