### PR TITLE
Support PaddleSeg models

### DIFF
--- a/paddle2onnx/op_mapper/logic.py
+++ b/paddle2onnx/op_mapper/logic.py
@@ -14,15 +14,18 @@
 
 from __future__ import absolute_import
 
-from .op_mapper import OpMapper, register_op_mapper
-from . import nn
-from . import math
-from . import activation
-from . import tensor
-from . import logic
+import numpy as np
+from paddle2onnx.constant import dtypes
+from paddle2onnx.op_mapper import OpMapper as op_mapper
 
-from .detection import yolo_box
-from .detection import multiclass_nms
-from .detection import prior_box
-from .detection import box_coder
-from .sequence import im2sequence
+
+@op_mapper('greater_equal')
+class GreaterOrEqual():
+    support_opset_verison_range = (12, )
+
+    @classmethod
+    def opset_12(cls, graph, node, **kw):
+        onnx_node = graph.make_node(
+            'GreaterOrEqual',
+            inputs=[node.input('X', 0), node.input('Y', 0)],
+            outputs=node.output('Out'))

--- a/paddle2onnx/op_mapper/mapper_helper.py
+++ b/paddle2onnx/op_mapper/mapper_helper.py
@@ -15,6 +15,13 @@
 from paddle2onnx.constant import dtypes
 
 
+def get_auto_padding(in_size, kernel, stride, dilation):
+    pad_size = (in_size - 1) * stride + 1 - in_size + dilation * (kernel - 1)
+    pad_upper = int(pad_size / 2)
+    pad_lower = pad_size - pad_upper
+    return [pad_upper, pad_lower]
+
+
 def slice_helper(graph, input, axes, starts, ends, outputs=None):
     if graph.opset_version < 10:
         slice_node = graph.make_node(

--- a/paddle2onnx/op_mapper/mapper_helper.py
+++ b/paddle2onnx/op_mapper/mapper_helper.py
@@ -15,18 +15,11 @@
 from paddle2onnx.constant import dtypes
 
 
-def get_auto_padding(in_size, kernel, stride, dilation):
-    pad_size = (in_size - 1) * stride + 1 - in_size + dilation * (kernel - 1)
-    pad_upper = int(pad_size / 2)
-    pad_lower = pad_size - pad_upper
-    return [pad_upper, pad_lower]
-
-
 def slice_helper(graph, input, axes, starts, ends, outputs=None):
     if graph.opset_version < 10:
         slice_node = graph.make_node(
             "Slice",
-            inputs=input,
+            inputs=[input],
             outputs=outputs,
             axes=axes,
             starts=starts,

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -147,6 +147,18 @@ class Mul():
             'MatMul', inputs=[flatten_x, flatten_y], outputs=node.output('Out'))
 
 
+@op_mapper('bmm')
+class BMM():
+    support_opset_verision_range = (1, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        x = node.input('X', 0)
+        y = node.input('Y', 0)
+        mul_node = graph.make_node(
+            'MatMul', inputs=[x, y], outputs=node.output('Out'))
+
+
 @op_mapper('sum')
 class Sum():
     support_opset_verison_range = (1, 12)
@@ -172,7 +184,7 @@ class Floor():
         'reduce_mean': 'ReduceMean',
         'reduce_sum': 'ReduceSum',
         'reduce_min': 'ReduceMin',
-        'reduce_max': 'ReudceMax'
+        'reduce_max': 'ReduceMax'
     })
 class ReduceMean():
     support_opset_verison_range = (1, 12)

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -30,6 +30,22 @@ class MatMul():
         graph.make_node('MatMul', inputs=[x, y], outputs=node.output('Out'))
 
 
+@op_mapper('matmul_v2')
+class MatMul():
+    support_opset_verision_range = (1, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        x = node.input('X', idx=0)
+        y = node.input('Y', idx=0)
+        out = node.output('Out')
+        if node.attr('trans_x'):
+            x = graph.make_node('Transpose', inputs=[x])
+        if node.attr('trans_y'):
+            y = graph.make_node('Transpose', inputs=[y])
+        graph.make_node('MatMul', inputs=[x, y], outputs=out)
+
+
 @op_mapper('exp')
 class Exp():
     support_opset_verision_range = (1, 12)

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -127,7 +127,7 @@ class OpMapper(object):
                 node.type for node in op_mapping_status[OP_MAPPING_NO_VERSION]
             ])
             error_info = "\nThere's {} ops are not supported in opset_version {}, please try other opset versions\n".format(
-                len(unsupported_op_types), self.opset_version)
+                len(unsupported_op_types), opset_version)
 
             for op_type in unsupported_op_types:
                 error_info += "=========== {} ===========\n".format(op_type)


### PR DESCRIPTION
Support PaddleSeg models:

- DANet(ResNet50)|
- DeepLabv3(ResNet50)
- DeepLabv3p(ResNet50)
- UNet 
- FCN(HRNetw18)  
- GCNet
- BiSeNet
- OCRNet(HRNetw18)

add op mapper:

- bmm
- layer_norm
- expand_as_v2
- uniform_random
- pad3d 
- bilinear_interp_v2
- nearest_interp_v2

add feature for op mapper:

- conv2d support padding model "SAME" or "VALID"
- adaptive pool update check of out_size & in_size

fix some bug:
- error typo in reduce_max   op mapper
- fix bug in op mapper status checker
