### PR TITLE
增加custom op的导出模式选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Combined PaddlePaddle model(parameters saved in one binary file)
 |--save_file | the directory path for the exported ONNX model|
 |--opset_version | **[Optional]** To configure the ONNX Opset version. Opset 9-11 are stably supported. Default value is 9.|
 |--enable_onnx_checker| **[Optional]**  To check the validity of the exported ONNX model. It is suggested to turn on the switch. If set to True, onnx>=1.7.0 is required. Default value is False|
+|--enable_paddle_fallback| **[Optional]**  Whether custom op is exported using paddle_fallback mode. Default value is False|
 |--version |**[Optional]** check the version of paddle2onnx |
 
 - Two types of PaddlePaddle models

--- a/README_zh.md
+++ b/README_zh.md
@@ -56,6 +56,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--save_file | 指定转换后的模型保存目录路径 |
 |--opset_version | **[可选]** 配置转换为ONNX的OpSet版本，目前比较稳定地支持9、10、11三个版本，默认为9 |
 |--enable_onnx_checker| **[可选]**  配置是否检查导出为ONNX模型的正确性, 建议打开此开关。若指定为True，需要安装 onnx>=1.7.0, 默认为False|
+--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
 |--version |**[可选]** 查看paddle2onnx版本 |
 
 - PaddlePaddle模型的两种存储形式：

--- a/README_zh.md
+++ b/README_zh.md
@@ -56,7 +56,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--save_file | 指定转换后的模型保存目录路径 |
 |--opset_version | **[可选]** 配置转换为ONNX的OpSet版本，目前比较稳定地支持9、10、11三个版本，默认为9 |
 |--enable_onnx_checker| **[可选]**  配置是否检查导出为ONNX模型的正确性, 建议打开此开关。若指定为True，需要安装 onnx>=1.7.0, 默认为False|
---enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
+|--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
 |--version |**[可选]** 查看paddle2onnx版本 |
 
 - PaddlePaddle模型的两种存储形式：

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -64,6 +64,12 @@ def arg_parser():
         help="whether check onnx model validity, if True, please 'pip install onnx'"
     )
     parser.add_argument(
+        "--enable_paddle_fallback",
+        type=ast.literal_eval,
+        default=False,
+        help="whether use PaddleFallback for custom op, default is False"
+    )
+    parser.add_argument(
         "--version",
         "-v",
         action="store_true",
@@ -77,7 +83,8 @@ def program2onnx(model_dir,
                  model_filename=None,
                  params_filename=None,
                  opset_version=9,
-                 enable_onnx_checker=False):
+                 enable_onnx_checker=False,
+                 operator_export_type="ONNX"):
     try:
         import paddle
     except:
@@ -111,7 +118,8 @@ def program2onnx(model_dir,
         feed_var_names=feed_var_names,
         target_vars=fetch_vars,
         opset_version=opset_version,
-        enable_onnx_checker=enable_onnx_checker)
+        enable_onnx_checker=enable_onnx_checker,
+        operator_export_type=operator_export_type)
 
 
 def main():
@@ -133,13 +141,18 @@ def main():
 
     assert args.model_dir is not None, "--model_dir should be defined while translating paddle model to onnx"
     assert args.save_file is not None, "--save_file should be defined while translating paddle model to onnx"
+    
+    operator_export_type = "ONNX"
+    if args.enable_paddle_fallback:
+        operator_export_type = "PaddleFallback"
     program2onnx(
         args.model_dir,
         args.save_file,
         args.model_filename,
         args.params_filename,
         opset_version=args.opset_version,
-        enable_onnx_checker=args.enable_onnx_checker)
+        enable_onnx_checker=args.enable_onnx_checker,
+        operator_export_type=operator_export_type)
 
 
 if __name__ == "__main__":

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -28,8 +28,9 @@ def export_onnx(paddle_graph,
                 save_file,
                 opset_version=9,
                 enable_onnx_checker=False,
+                operator_export_type="ONNX",
                 verbose=False):
-    onnx_graph = ONNXGraph.build(paddle_graph, opset_version, verbose)
+    onnx_graph = ONNXGraph.build(paddle_graph, opset_version, operator_export_type, verbose)
     onnx_graph = PassManager.run_pass(onnx_graph, ['inplace_node_pass'])
 
     onnx_proto = onnx_graph.export_proto(enable_onnx_checker)
@@ -49,6 +50,7 @@ def program2onnx(program,
                  target_vars=None,
                  opset_version=9,
                  enable_onnx_checker=False,
+                 operator_export_type="ONNX",
                  **configs):
     from paddle import fluid
     if hasattr(paddle, 'enable_static'):
@@ -74,7 +76,7 @@ def program2onnx(program,
 
         paddle_graph = PaddleGraph.build_from_program(program, feed_var_names,
                                                       target_vars, scope)
-        export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker)
+        export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker, operator_export_type)
     else:
         raise TypeError(
             "the input 'program' should be 'Program', but received type is %s."
@@ -140,8 +142,20 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
             raise TypeError(
                 "The 'enable_onnx_checker' should be 'bool', but received type is %s."
                 % type(configs['enable_onnx_checker']))
+    
+    operator_export_type = "ONNX"
+    enable_paddle_fallback = False
+    if 'enable_paddle_fallback' in configs:
+        if isinstance(configs['enable_paddle_fallback'], bool):
+            enable_paddle_fallback = configs['enable_paddle_fallback']
+            if enable_paddle_fallback:
+                operator_export_type = "PaddleFallback"
+        else:
+            raise TypeError(
+                "The 'enable_paddle_fallback' should be 'bool', but received type is %s."
+                % type(configs['enable_paddle_fallback']))
 
     paddle_graph = PaddleGraph.build_from_dygraph(layer, inner_input_spec,
                                                   output_spec)
-    export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker,
+    export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker, operator_export_type,
                 verbose)

--- a/paddle2onnx/graph/onnx_graph.py
+++ b/paddle2onnx/graph/onnx_graph.py
@@ -70,9 +70,10 @@ class ONNXNode(Node):
 
 
 class ONNXGraph(Graph):
-    def __init__(self, paddle_graph, opset_version, block=None):
+    def __init__(self, paddle_graph, opset_version, operator_export_type="ONNX" ,block=None):
         super(ONNXGraph, self).__init__()
         self.opset_version = opset_version
+        self.operator_export_type = operator_export_type
         self.ctx = paddle_graph
         self.custom = []
         self.update_opset_version()
@@ -195,7 +196,7 @@ class ONNXGraph(Graph):
         OpMapper.check_support_status(node_map, self.opset_version)
         # build op nodes
         for name, node in list(node_map.items()):
-            OpMapper.mapping(self, node)
+            OpMapper.mapping(self, node, self.operator_export_type)
 
     def make_value_info(self, name, shape, dtype):
         tensor_info = helper.make_tensor_value_info(
@@ -235,8 +236,8 @@ class ONNXGraph(Graph):
         return onnx_proto
 
     @staticmethod
-    def build(paddle_graph, opset_version, verbose=False):
-        onnx_graph = ONNXGraph(paddle_graph, opset_version=opset_version)
+    def build(paddle_graph, opset_version, operator_export_type="ONNX", verbose=False):
+        onnx_graph = ONNXGraph(paddle_graph, opset_version=opset_version, operator_export_type=operator_export_type)
         onnx_graph.build_parameters(paddle_graph.parameters)
         onnx_graph.build_input_nodes(paddle_graph.input_nodes)
         onnx_graph.build_output_nodes(paddle_graph.output_nodes)

--- a/paddle2onnx/op_mapper/custom_paddle_op/anchor_generator.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/anchor_generator.py
@@ -18,7 +18,8 @@ import numpy as np
 import paddle
 from paddle.fluid import layers
 from paddle2onnx.op_mapper import CustomPaddleOp, register_custom_paddle_op
-
+from paddle2onnx.op_mapper import OpMapper as op_mapper
+from paddle2onnx.op_mapper import mapper_helper
 
 class AnchorGenerator(CustomPaddleOp):
     def __init__(self, node, **kw):
@@ -78,5 +79,19 @@ class AnchorGenerator(CustomPaddleOp):
             vars, repeat_times=(h, w, tensor_len_shape, tensor_one))
         return {'Anchors': [anchors], 'Variances': [vars]}
 
+@op_mapper('anchor_generator')
+class Anchors_generator:
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        node = graph.make_node(
+            'anchor_generator',
+            inputs=node.input('Input'),
+            outputs=node.utput('Anchors') + node.output('Variances'),
+            anchor_sizes = node.attr('anchor_sizes'),
+            aspect_ratios = node.attr('aspect_ratios'),
+            offset = node.attr('offset'),
+            strides = node.attr('stride'),
+            variances = node.attr('variances'),
+            domain = 'custom')
 
 register_custom_paddle_op('anchor_generator', AnchorGenerator)

--- a/paddle2onnx/op_mapper/custom_paddle_op/anchor_generator.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/anchor_generator.py
@@ -86,7 +86,7 @@ class Anchors_generator:
         node = graph.make_node(
             'anchor_generator',
             inputs=node.input('Input'),
-            outputs=node.utput('Anchors') + node.output('Variances'),
+            outputs=node.output('Anchors') + node.output('Variances'),
             anchor_sizes = node.attr('anchor_sizes'),
             aspect_ratios = node.attr('aspect_ratios'),
             offset = node.attr('offset'),

--- a/paddle2onnx/op_mapper/custom_paddle_op/box_clip.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/box_clip.py
@@ -18,7 +18,8 @@ import numpy as np
 import paddle
 from paddle.fluid import layers
 from paddle2onnx.op_mapper import CustomPaddleOp, register_custom_paddle_op
-
+from paddle2onnx.op_mapper import OpMapper as op_mapper
+from paddle2onnx.op_mapper import mapper_helper
 
 class BoxClip(CustomPaddleOp):
     def __init__(self, node, **kw):
@@ -43,5 +44,13 @@ class BoxClip(CustomPaddleOp):
 
         return {'Output': [cliped_box]}
 
-
+@op_mapper('box_clip')
+class Boxclip:
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        node = graph.make_node(
+            'box_clip',
+            inputs=node.input('Input')+node.input('ImInfo'),
+            outputs=node.output('Output'),
+            domain = 'custom')
 register_custom_paddle_op('box_clip', BoxClip)

--- a/paddle2onnx/op_mapper/custom_paddle_op/collect_fpn_proposals.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/collect_fpn_proposals.py
@@ -18,6 +18,8 @@ import numpy as np
 import paddle
 from paddle.fluid import layers
 from paddle2onnx.op_mapper import CustomPaddleOp, register_custom_paddle_op
+from paddle2onnx.op_mapper import OpMapper as op_mapper
+from paddle2onnx.op_mapper import mapper_helper
 
 
 class CollectFpnProposals(CustomPaddleOp):
@@ -39,5 +41,15 @@ class CollectFpnProposals(CustomPaddleOp):
         rois = paddle.gather(multi_level_rois, index, axis=0)
         return {"FpnRois": [rois]}
 
-
+@op_mapper('collect_fpn_proposals')
+class Collectfpnproposals:
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        node = graph.make_node(
+            'collect_fpn_proposals',
+            inputs=node.input('MultiLevelRois')+ node.input('MultiLevelScores'),
+            outputs=node.output('FpnRois'),
+            post_nms_top_n = node.attr('post_nms_topN'),
+            domain = 'custom')
+            
 register_custom_paddle_op('collect_fpn_proposals', CollectFpnProposals)

--- a/paddle2onnx/op_mapper/custom_paddle_op/deformable_conv.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/deformable_conv.py
@@ -20,6 +20,8 @@ from paddle.fluid import layers
 from paddle2onnx.op_mapper import CustomPaddleOp, register_custom_paddle_op
 from paddle2onnx import utils
 from paddle2onnx.constant import dtypes
+from paddle2onnx.op_mapper import OpMapper as op_mapper
+from paddle2onnx.op_mapper import mapper_helper
 
 
 class DeformConv2d(CustomPaddleOp):
@@ -276,5 +278,19 @@ class DeformConv2d(CustomPaddleOp):
                                              offset_w * self.kernel_size))
         return x_offset
 
-
+@op_mapper('deformable_conv')
+class Deformconv2d:
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        node = graph.make_node(
+            'deformable_conv',
+            inputs=node.input('Input')+node.input('Filter')+node.input('Mask')+node.input('Offset'),
+            outputs=node.output('Output'),
+            stride = node.attr('strides'),
+            padding = node.attr('paddings'),
+            groups = node.attr('groups'),
+            dilation = node.attr('dilations'),
+            deformable_groups = node.attr('deformable_groups'),
+            domain = 'custom')
+            
 register_custom_paddle_op('deformable_conv', DeformConv2d)

--- a/paddle2onnx/op_mapper/custom_paddle_op/generate_proposals.py
+++ b/paddle2onnx/op_mapper/custom_paddle_op/generate_proposals.py
@@ -19,6 +19,8 @@ import paddle
 import math
 from paddle.fluid import layers
 from paddle2onnx.op_mapper import CustomPaddleOp, register_custom_paddle_op
+from paddle2onnx.op_mapper import OpMapper as op_mapper
+from paddle2onnx.op_mapper import mapper_helper
 
 BBOX_CLIP_DEFAULT = math.log(1000.0 / 16.0)
 
@@ -163,5 +165,19 @@ class GenerateProposals(CustomPaddleOp):
             anchors, bboxdeltas, iminfo, scores, variances)
         return {'RpnRoiProbs': [new_scores], 'RpnRois': [proposals]}
 
-
+@op_mapper('generate_proposals')
+class Generateproposals:
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        node = graph.make_node(
+            'generate_proposals',
+            inputs=node.input('Anchors')+node.input('BboxDeltas')+node.input('ImInfo')+node.input('Scores')+node.input('Variances'),
+            outputs=node.output('RpnRoiProbs') + node.output('RpnRois'),
+            eta = node.attr('eta'),
+            min_size = node.attr('min_size'),
+            nms_thresh = node.attr('nms_thresh'),
+            post_nms_topN = node.attr('post_nms_topN'),
+            pre_nms_topN = node.attr('pre_nms_topN'),
+            domain = 'custom')
+            
 register_custom_paddle_op('generate_proposals', GenerateProposals)

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -92,7 +92,7 @@ class OpMapper(object):
                     opset_dict[version] = (v, self.kwargs)
 
     @staticmethod
-    def mapping(graph, node, combiane_custom=False):
+    def mapping(graph, node, combine_custom=False):
         try:
             if node.type in OpMapper.REGISTER_CUSTOM_PADDLE_OP:
                 if combiane_custom:

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -92,10 +92,9 @@ class OpMapper(object):
                     opset_dict[version] = (v, self.kwargs)
 
     @staticmethod
-    def mapping(graph, node, combiane_custom=True):
+    def mapping(graph, node, combiane_custom=False):
         try:
-            if node.type in OpMapper.REGISTER_CUSTOM_PADDLE_OP: #如果是一个用户自定义的o
-                print("here is custom:", node.type)
+            if node.type in OpMapper.REGISTER_CUSTOM_PADDLE_OP:
                 if combiane_custom:
                     opsets = OpMapper.OPSETS[node.type]
                     versions = list(opsets.keys())

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -92,10 +92,10 @@ class OpMapper(object):
                     opset_dict[version] = (v, self.kwargs)
 
     @staticmethod
-    def mapping(graph, node, combine_custom=False):
+    def mapping(graph, node, operator_export_type="ONNX"):
         try:
             if node.type in OpMapper.REGISTER_CUSTOM_PADDLE_OP:
-                if combine_custom:
+                if operator_export_type in ["PaddleFallback"]:
                     opsets = OpMapper.OPSETS[node.type]
                     versions = list(opsets.keys())
                     convert_version = get_max_support_version(versions,

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -95,7 +95,7 @@ class OpMapper(object):
     def mapping(graph, node, combine_custom=False):
         try:
             if node.type in OpMapper.REGISTER_CUSTOM_PADDLE_OP:
-                if combiane_custom:
+                if combine_custom:
                     opsets = OpMapper.OPSETS[node.type]
                     versions = list(opsets.keys())
                     convert_version = get_max_support_version(versions,


### PR DESCRIPTION
增加custom op的导出模式选项，在使用命令行进行导出时，使用--enable_paddle_fallback参数进行指定，如果设置为True则表示使用paddle_fallback进行导出，若设置为False则分解为ONNX op进行导出，默认为False。