### PR TITLE
Fix bug for resize operator

### DIFF
--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -962,6 +962,7 @@ class Resize():
                         'dtype': dtypes.ONNX.FLOAT,
                         'value': [1, 1, scale_h, scale_w]
                     })
+                inputs.append(scale_node)
             else:
                 raise Exception("Unexpected situation happend")
         graph.make_node(

--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -949,7 +949,7 @@ class Resize():
         else:
             out_shape = [node.attr('out_h'), node.attr('out_w')]
             scale = node.attr('scale')
-             if isinstance(scale, (tuple, list)):
+            if isinstance(scale, (tuple, list)):
                 scale_h = scale[0]
                 scale_w = scale[1]
             else:

--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -949,14 +949,19 @@ class Resize():
         else:
             out_shape = [node.attr('out_h'), node.attr('out_w')]
             scale = node.attr('scale')
+             if isinstance(scale, (tuple, list)):
+                scale_h = scale[0]
+                scale_w = scale[1]
+            else:
+                scale_h = scale
+                scale_w = scale
             if out_shape.count(-1) > 0:
                 scale_node = graph.make_node(
                     'Constant',
                     attrs={
                         'dtype': dtypes.ONNX.FLOAT,
-                        'value': [1, 1, scale, scale]
+                        'value': [1, 1, scale_h, scale_w]
                     })
-                inputs.append(scale_node)
             else:
                 raise Exception("Unexpected situation happend")
         graph.make_node(


### PR DESCRIPTION
fix issue of https://github.com/PaddlePaddle/PaddleOCR/issues/4141 which will cause problem while `scale` is a type of tuple or list in opset version 9