### PR TITLE
include persistable buffers in onnx export

### DIFF
--- a/paddle2onnx/graph/paddle_graph.py
+++ b/paddle2onnx/graph/paddle_graph.py
@@ -225,7 +225,7 @@ class PaddleGraph(Graph):
             program = layer.program()
             parameters_dict = {}
             pruned_vars = program.global_block().vars
-            for param in layer.parameters():
+            for param in layer.parameters() + layer.buffers():
                 if param.name.endswith('feed') or param.name.endswith('fetch'):
                     continue
                 if not param.persistable:
@@ -258,7 +258,7 @@ class PaddleGraph(Graph):
                 layer, input_spec, output_spec)
             parameters_dict = {}
             pruned_vars = program.global_block().vars
-            for param in layer.parameters():
+            for param in layer.parameters() + layer.buffers():
                 if param.name.endswith('feed') or param.name.endswith('fetch'):
                     continue
                 if not param.persistable:


### PR DESCRIPTION
Buffers are not considered when exporting a model to onnx.
This PR will add buffer data to the exported graph if it is marked as persistent
(although buffer persistency is not fully working right now in `paddlepaddle`, see: https://github.com/PaddlePaddle/Paddle/issues/36049)