### PR TITLE
【PaddlePaddle Hackathon】在Paddle2ONNX 新增10个 Paddle 2.0 API 支持

### DIFF
--- a/paddle2onnx/op_mapper/logic.py
+++ b/paddle2onnx/op_mapper/logic.py
@@ -50,7 +50,8 @@ class NotEqual():
     @classmethod
     def opset_1(cls, graph, node, **kw):
         equal_val = graph.make_node(
-            'Equal', inputs=[node.input('X', 0), node.input('Y', 0)])
+            'Equal', inputs=[node.input('X', 0),
+                             node.input('Y', 0)])
         k_node = graph.make_node(
             'Cast', inputs=[equal_val], to=dtypes.ONNX.INT64)
         const = graph.make_node('Constant', dtype=dtypes.ONNX.INT64, value=1)
@@ -108,3 +109,15 @@ class Equal():
             'Equal',
             inputs=[node.input('X', 0), node.input('Y', 0)],
             outputs=node.output('Out'))
+
+
+@op_mapper('isfinite_v2')
+class Isfinite():
+    support_opset_verision_range = (10, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        is_inf = graph.make_node('IsInf', inputs=node.input('X', 0))
+        is_nan = graph.make_node('IsNaN', inputs=node.input('X', 0))
+        finite = graph.make_node('Or', inputs=[is_inf, is_nan])
+        graph.make_node('Not', inputs=[finite], outputs=node.output('Out'))

--- a/paddle2onnx/op_mapper/logic.py
+++ b/paddle2onnx/op_mapper/logic.py
@@ -116,7 +116,7 @@ class Isfinite():
     support_opset_verision_range = (10, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_10(cls, graph, node, **kw):
         is_inf = graph.make_node('IsInf', inputs=node.input('X', 0))
         is_nan = graph.make_node('IsNaN', inputs=node.input('X', 0))
         finite = graph.make_node('Or', inputs=[is_inf, is_nan])

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -504,14 +504,26 @@ class ArgMin():
 
     @classmethod
     def opset_1(cls, graph, node, **kw):
-        graph.make_node(
-            'ArgMin',
-            inputs=node.input('X'),
-            outputs=node.output('Out'),
-            attrs={
-                'axis': node.attr('axis'),
-                'keepdims': node.attr('keepdims')
-            })
+        if node.attr('flatten'):
+            flatten = graph.make_node('Flatten', inputs=node.input('X'), axis=0)
+            squeeze_node = graph.make_node('Squeeze', inputs=flatten)
+            graph.make_node(
+                'ArgMin', inputs=squeeze_node, outputs=node.output('Out'))
+        else:
+            if node.attr('keepdims'):
+                graph.make_node(
+                    'ArgMin',
+                    inputs=node.input('X'),
+                    outputs=node.output('Out'),
+                    axis=node.attr('axis'),
+                    keepdims=1)
+            else:
+                graph.make_node(
+                    'ArgMin',
+                    inputs=node.input('X'),
+                    outputs=node.output('Out'),
+                    axis=node.attr('axis'),
+                    keepdims=0)
 
 
 #

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -91,7 +91,7 @@ class Acos():
     supports_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Acos', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -101,7 +101,7 @@ class Asin():
     supports_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Asin', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -111,7 +111,7 @@ class Atan():
     supports_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Atan', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -121,7 +121,7 @@ class Ceil():
     supports_opset_version_range = (6, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_6(cls, graph, node, **kw):
         graph.make_node(
             'Ceil', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -131,7 +131,7 @@ class Cos():
     supports_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Cos', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -141,7 +141,7 @@ class Cosh():
     supports_opset_version_range = (9, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_9(cls, graph, node, **kw):
         graph.make_node(
             'Cosh', inputs=node.input('X'), outputs=node.output('Out'))
 

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -86,6 +86,66 @@ class Abs:
             'Abs', inputs=node.input('X'), outputs=node.output('Out'))
 
 
+@op_mapper('acos')
+class Acos():
+    supports_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Acos', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('asin')
+class Asin():
+    supports_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Asin', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('atan')
+class Atan():
+    supports_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Atan', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('ceil')
+class Ceil():
+    supports_opset_version_range = (6, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Ceil', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('cos')
+class Cos():
+    supports_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Cos', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('cosh')
+class Cosh():
+    supports_opset_version_range = (9, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Cosh', inputs=node.input('X'), outputs=node.output('Out'))
+
+
 @op_mapper(
     [
         'elementwise_add',
@@ -119,8 +179,8 @@ class ElementwiseOps():
         x_shape = node.input_shape('X', 0)
         y_shape = node.input_shape('Y', 0)
 
-        if axis == -1 or axis == (len(x_shape) - 1
-                                  ) or len(x_shape) == len(y_shape):
+        if axis == -1 or axis == (
+                len(x_shape) - 1) or len(x_shape) == len(y_shape):
             onnx_node = graph.make_node(
                 op_type, inputs=[x, y], outputs=node.output('Out'))
         else:
@@ -154,8 +214,8 @@ class ElementWiseFloorDiv():
         is_int = False
         if x_dtype.count('int') > 0 and y_dtype.count('int') > 0:
             is_int = True
-        if axis == -1 or axis == (len(x_shape) - 1
-                                  ) or len(x_shape) == len(y_shape):
+        if axis == -1 or axis == (
+                len(x_shape) - 1) or len(x_shape) == len(y_shape):
             if is_int:
                 graph.make_node(
                     'Div', inputs=[x, y], outputs=node.output('Out'))
@@ -432,8 +492,26 @@ class ArgMax():
             'ArgMax',
             inputs=node.input('X'),
             outputs=node.output('Out'),
-            attrs={'axis': node.attr('axis'),
-                   'keepdims': 0})
+            attrs={
+                'axis': node.attr('axis'),
+                'keepdims': node.attr('keepdims')
+            })
+
+
+@op_mapper('arg_min')
+class ArgMin():
+    support_opset_version_range = (1, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'ArgMin',
+            inputs=node.input('X'),
+            outputs=node.output('Out'),
+            attrs={
+                'axis': node.attr('axis'),
+                'keepdims': node.attr('keepdims')
+            })
 
 
 #
@@ -521,15 +599,17 @@ class Scale():
         else:
             scale_node = graph.make_node(
                 'Constant',
-                attrs={'dtype': dtypes.ONNX.FLOAT,
-                       'value': [scale]})
+                attrs={
+                    'dtype': dtypes.ONNX.FLOAT,
+                    'value': [scale]
+                })
             bias_node = graph.make_node(
-                'Constant',
-                attrs={'dtype': dtypes.ONNX.FLOAT,
-                       'value': [bias]})
+                'Constant', attrs={
+                    'dtype': dtypes.ONNX.FLOAT,
+                    'value': [bias]
+                })
             cast_node = graph.make_node(
-                'Cast', inputs=node.input('X'),
-                attrs={'to': dtypes.ONNX.FLOAT})
+                'Cast', inputs=node.input('X'), attrs={'to': dtypes.ONNX.FLOAT})
             if node.attr('bias_after_scale'):
                 node1 = graph.make_node('Mul', inputs=[cast_node, scale_node])
                 node2 = graph.make_node(

--- a/paddle2onnx/op_mapper/nn.py
+++ b/paddle2onnx/op_mapper/nn.py
@@ -190,7 +190,7 @@ class ELU():
     support_opset_verision_range = (1, 12)
 
     @classmethod
-    def opset_6(cls, graph, node, **kw):
+    def opset_1(cls, graph, node, **kw):
         node = graph.make_node(
             'Elu',
             inputs=node.input('X'),
@@ -200,7 +200,7 @@ class ELU():
 
 @op_mapper('hard_shrink')
 class Hardshrink():
-    support_opset_verision_range = (1, 12)
+    support_opset_verision_range = (9, 12)
 
     @classmethod
     def opset_9(cls, graph, node, **kw):

--- a/paddle2onnx/op_mapper/nn.py
+++ b/paddle2onnx/op_mapper/nn.py
@@ -109,8 +109,8 @@ class Pool():
 
     @classmethod
     def opset_1(cls, graph, node, **kw):
-        if node.attr('global_pooling') or (node.attr('adaptive') and
-                                           node.attr('ksize') == [1, 1]):
+        if node.attr('global_pooling') or (node.attr('adaptive')
+                                           and node.attr('ksize') == [1, 1]):
             onnx_node = graph.make_node(
                 cls.pool_type[node.attr('pooling_type')][1],
                 inputs=node.input('X'),
@@ -130,8 +130,8 @@ class Pool():
             if not cls.is_same_span(input_h, output_h) or not cls.is_same_span(
                     input_w, output_w):
                 raise Exception(
-                    "Cannot convert adaptive pool with input_size: {}, output_size: {}".
-                    format(
+                    "Cannot convert adaptive pool with input_size: {}, output_size: {}"
+                    .format(
                         node.input_shape('X', 0), node.output_shape('Out', 0)))
             else:
                 attrs = {
@@ -183,6 +183,32 @@ class Pool():
                 inputs=node.input('X'),
                 outputs=node.output('Out'),
                 attrs=attrs)
+
+
+@op_mapper('elu')
+class ELU():
+    support_opset_verision_range = (1, 12)
+
+    @classmethod
+    def opset_6(cls, graph, node, **kw):
+        node = graph.make_node(
+            'Elu',
+            inputs=node.input('X'),
+            outputs=node.output('Out'),
+            alpha=node.attr('alpha'))
+
+
+@op_mapper('hard_shrink')
+class Hardshrink():
+    support_opset_verision_range = (1, 12)
+
+    @classmethod
+    def opset_9(cls, graph, node, **kw):
+        node = graph.make_node(
+            'Shrink',
+            inputs=node.input('X'),
+            outputs=node.output('Out'),
+            lambd=node.attr('threshold'))
 
 
 @op_mapper('norm')
@@ -383,7 +409,9 @@ class InstanceNorm():
 
     @classmethod
     def opset_1(cls, graph, node, **kw):
-        onnx_attr = {'epsilon': node.attr('epsilon'), }
+        onnx_attr = {
+            'epsilon': node.attr('epsilon'),
+        }
         inputs = node.input('X') + node.input('Scale') + node.input('Bias')
         onnx_node = graph.make_node(
             'InstanceNormalization',
@@ -406,8 +434,10 @@ class Dropout():
         elif dropout_mode == 'downgrade_in_infer':
             scale_node = graph.make_node(
                 'Constant',
-                attrs={'dtype': dtypes.ONNX.FLOAT,
-                       'value': 1 - dropout_prob})
+                attrs={
+                    'dtype': dtypes.ONNX.FLOAT,
+                    'value': 1 - dropout_prob
+                })
             graph.make_node(
                 "Mul",
                 inputs=[node.input('X')[0], scale_node],
@@ -424,18 +454,23 @@ class RoiAlign():
     def opset_10(cls, graph, node, **kw):
         rois_shape = graph.make_node('Shape', inputs=[node.input('ROIs', 0)])
         starts = graph.make_node(
-            'Constant', attrs={'dtype': dtypes.ONNX.INT64,
-                               'value': [0]})
+            'Constant', attrs={
+                'dtype': dtypes.ONNX.INT64,
+                'value': [0]
+            })
         ends = graph.make_node(
-            'Constant', attrs={'dtype': dtypes.ONNX.INT64,
-                               'value': [1]})
+            'Constant', attrs={
+                'dtype': dtypes.ONNX.INT64,
+                'value': [1]
+            })
         num_rois = graph.make_node('Slice', inputs=[rois_shape, starts, ends])
         zero = graph.make_node(
             'Constant', dims=[1], dtype=dtypes.ONNX.INT64, value=[0])
         batch_indices = graph.make_node('Expand', inputs=[zero, num_rois])
         node = graph.make_node(
             'RoiAlign',
-            inputs=[node.input('X', 0), node.input('ROIs', 0), batch_indices],
+            inputs=[node.input('X', 0),
+                    node.input('ROIs', 0), batch_indices],
             outputs=node.output('Out'),
             mode='avg',
             output_height=node.attr('pooled_height'),
@@ -491,8 +526,8 @@ class RNN():
         input_weight = graph.make_node('Concat', inputs=input_weights, axis=0)
         hidden_weight = graph.make_node('Concat', inputs=hidden_weights, axis=0)
         input_bias = unsqueeze_weights[param_list_len // 2:param_list_len:2]
-        hidden_bias = unsqueeze_weights[param_list_len // 2 + 1:param_list_len:
-                                        2]
+        hidden_bias = unsqueeze_weights[param_list_len // 2 +
+                                        1:param_list_len:2]
 
         input_bias = graph.make_node('Concat', inputs=input_bias, axis=0)
         hidden_bias = graph.make_node('Concat', inputs=hidden_bias, axis=0)
@@ -533,8 +568,8 @@ class RNN():
             for layer in range(num_layers):
                 param_inputs = cls.make_param_inputs(graph, node, layer,
                                                      hidden_size, num_layers)
-                init_param_inputs = cls.make_init_param_inputs(graph, node,
-                                                               layer)
+                init_param_inputs = cls.make_init_param_inputs(
+                    graph, node, layer)
                 if layer + 1 < num_layers:
                     rnn_outputs = 3
                     output_y = None
@@ -561,8 +596,8 @@ class RNN():
             for layer in range(num_layers):
                 param_inputs = cls.make_param_inputs(graph, node, layer,
                                                      hidden_size, num_layers)
-                init_param_inputs = cls.make_init_param_inputs(graph, node,
-                                                               layer)
+                init_param_inputs = cls.make_init_param_inputs(
+                    graph, node, layer)
                 if layer + 1 < num_layers:
                     rnn_outputs = 2
                     output_y = None
@@ -570,8 +605,8 @@ class RNN():
                     rnn_outputs = [1] + node.output('State')
                     output_y = node.output('Out')
                 attrs = {
-                    'direction': 'bidirectional'
-                    if node.attr('is_bidirec') else 'forward',
+                    'direction':
+                    'bidirectional' if node.attr('is_bidirec') else 'forward',
                     'hidden_size': node.attr('hidden_size'),
                     'linear_before_reset': 1,
                 }

--- a/tests/test_acos.py
+++ b/tests/test_acos.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.acos(inputs)
+        return x
+
+
+def test_acos_7():
+    """
+    api: paddle.acos
+    op version: 7
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'acos', [7])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_acos_9():
+    """
+    api: paddle.acos
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'acos', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_acos_10():
+    """
+    api: paddle.acos
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'acos', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_acos_11():
+    """
+    api: paddle.acos
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'acos', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_acos_12():
+    """
+    api: paddle.acos
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'acos', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_argmin.py
+++ b/tests/test_argmin.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.argmin(inputs, axis=0)
+        return x
+
+
+def test_argmin_9():
+    """
+    api: paddle.argmin
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_10():
+    """
+    api: paddle.argmin
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_11():
+    """
+    api: paddle.argmin
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_12():
+    """
+    api: paddle.argmin
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_argmin.py
+++ b/tests/test_argmin.py
@@ -22,14 +22,16 @@ class Net(paddle.nn.Layer):
     simplr Net
     """
 
-    def __init__(self):
+    def __init__(self, axis=None, keepdim=False):
         super(Net, self).__init__()
+        self.axis = axis
+        self.keepdim = keepdim
 
     def forward(self, inputs):
         """
         forward
         """
-        x = paddle.argmin(inputs, axis=0)
+        x = paddle.argmin(inputs, axis=self.axis, keepdim=self.keepdim)
         return x
 
 
@@ -90,4 +92,51 @@ def test_argmin_12():
     obj.set_input_data(
         "input_data",
         paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_keepdim():
+    """
+    api: paddle.argmin
+    op version: 12
+    """
+    op = Net(keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_axis():
+    """
+    api: paddle.argmin
+    op version: 12
+    """
+    op = Net(axis=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_argmin_axis_keepdim():
+    """
+    api: paddle.argmin
+    op version: 12
+    """
+    op = Net(axis=1, keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'argmin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 3, 10]).astype('float32')))
     obj.run()

--- a/tests/test_asin.py
+++ b/tests/test_asin.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.asin(inputs)
+        return x
+
+
+def test_asin_9():
+    """
+    api: paddle.asin
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'asin', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_asin_10():
+    """
+    api: paddle.asin
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'asin', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_asin_11():
+    """
+    api: paddle.asin
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'asin', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_asin_12():
+    """
+    api: paddle.asin
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'asin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_atan.py
+++ b/tests/test_atan.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.atan(inputs)
+        return x
+
+
+def test_atan_9():
+    """
+    api: paddle.atan
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'atan', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_atan_10():
+    """
+    api: paddle.atan
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'atan', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_atan_11():
+    """
+    api: paddle.atan
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'atan', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_atan_12():
+    """
+    api: paddle.atan
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'atan', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_ceil.py
+++ b/tests/test_ceil.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.ceil(inputs)
+        return x
+
+
+def test_ceil_6():
+    """
+    api: paddle.ceil
+    op version: 6
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'ceil', [6])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_ceil_9():
+    """
+    api: paddle.ceil
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'ceil', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_ceil_10():
+    """
+    api: paddle.ceil
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'ceil', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_ceil_11():
+    """
+    api: paddle.ceil
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'ceil', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_ceil_12():
+    """
+    api: paddle.ceil
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'ceil', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_cos.py
+++ b/tests/test_cos.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.cos(inputs)
+        return x
+
+
+def test_cos_9():
+    """
+    api: paddle.cos
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cos', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cos_10():
+    """
+    api: paddle.cos
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cos', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cos_11():
+    """
+    api: paddle.cos
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cos', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cos_12():
+    """
+    api: paddle.cos
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cos', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_cosh.py
+++ b/tests/test_cosh.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.cosh(inputs)
+        return x
+
+
+def test_cosh_9():
+    """
+    api: paddle.cosh
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cosh', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cosh_10():
+    """
+    api: paddle.cosh
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cosh', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cosh_11():
+    """
+    api: paddle.cosh
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cosh', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_cosh_12():
+    """
+    api: paddle.cosh
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'cosh', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_isfinite.py
+++ b/tests/test_isfinite.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.isfinite(inputs)
+        return x.astype('float32')
+
+
+def test_isfinite_10():
+    """
+    api: paddle.isfinite
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'isfinite', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_isfinite_11():
+    """
+    api: paddle.isfinite
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'isfinite', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_isfinite_12():
+    """
+    api: paddle.isfinite
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'isfinite', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_nn_ELU.py
+++ b/tests/test_nn_ELU.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self._elu = paddle.nn.ELU(alpha=1.0)
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = self._elu(inputs)
+        return x
+
+
+def test_ELU_9():
+    """
+    api: paddle.ELU
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_ELU', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 1, 10]).astype('float32')))
+    obj.run()
+
+
+def test_ELU_10():
+    """
+    api: paddle.nn.ELU
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_ELU', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 1, 10]).astype('float32')))
+    obj.run()
+
+
+def test_ELU_11():
+    """
+    api: paddle.nn.ELU
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_ELU', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 1, 10]).astype('float32')))
+    obj.run()
+
+
+def test_ELU_12():
+    """
+    api: paddle.nn.ELU
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_ELU', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [3, 1, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_nn_Hardshrink.py
+++ b/tests/test_nn_Hardshrink.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self._hardshrink = paddle.nn.Hardshrink()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = self._hardshrink(inputs)
+        return x
+
+
+def test_hardshrink_9():
+    """
+    api: paddle.nn.hardshrink
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_hardshrink', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_hardshrink_10():
+    """
+    api: paddle.nn.hardshrink
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_hardshrink', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_hardshrink_11():
+    """
+    api: paddle.nn.hardshrink
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_hardshrink', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_hardshrink_12():
+    """
+    api: paddle.nn.hardshrink
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_hardshrink', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()


### PR DESCRIPTION
**PR types** ：New Operators

**Describe：**

Task:  #346

在Paddle2ONNX 新增10个 Paddle 2.0 API 支持

10个API具体为：
- paddle.acos(x, name=None)
- paddle.argmin(x, axis=None, keepdim=False, dtype='int64', name=None)
- paddle.asin(x, name=None)
- paddle.atan(x, name=None)
- paddle.ceil(x, name=None)
- paddle.cos(x, name=None)
- paddle.cosh(x, name=None)
- paddle.nn.ELU(alpha=1.0, name=None)
- paddle.nn.Hardshrink(threshold=0.5, name=None)
- paddle.isfinite(x, name=None)
