### PR TITLE
【PaddlePaddle Hackathon】在Paddle2ONNX 新增11个 Paddle 2.0 API 支持

### DIFF
--- a/paddle2onnx/op_mapper/activation.py
+++ b/paddle2onnx/op_mapper/activation.py
@@ -155,10 +155,10 @@ class Gelu():
 
 @op_mapper('selu')
 class Selu():
-    support_opset_verision_range = (6, 12)
+    support_opset_version_range = (6, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_6(cls, graph, node, **kw):
         graph.make_node(
             'Selu',
             inputs=node.input('X'),

--- a/paddle2onnx/op_mapper/activation.py
+++ b/paddle2onnx/op_mapper/activation.py
@@ -82,7 +82,8 @@ class PRelu():
 
         slope_node = node.input('Alpha')[0]
         if len(input_shape) != len(slope_shape):
-            assert len(slope_shape) == 1, "Slope shape is not expected for prelu"
+            assert len(
+                slope_shape) == 1, "Slope shape is not expected for prelu"
             shape_node = graph.make_node('Shape', inputs=node.input('X'))
             axes = [i for i in range(len(input_shape))]
             del axes[1]
@@ -102,7 +103,8 @@ class PRelu():
 
         slope_node = node.input('Alpha')[0]
         if len(input_shape) != len(slope_shape):
-            assert len(slope_shape) == 1, "Slope shape is not expected for prelu"
+            assert len(
+                slope_shape) == 1, "Slope shape is not expected for prelu"
             shape_node = graph.make_node('Shape', inputs=node.input('X'))
             value = [i for i in range(len(input_shape))]
             del value[1]
@@ -117,14 +119,14 @@ class PRelu():
             inputs=[node.input('X')[0], slope_node],
             outputs=node.output('Out'))
 
+
 @op_mapper('relu6')
 class Relu6():
     support_opset_verison_range = (1, 12)
 
     @classmethod
     def opset_1(cls, graph, node, **kw):
-        mapper_helper.clip_helper(graph,
-                                  node.input('X', 0),
+        mapper_helper.clip_helper(graph, node.input('X', 0),
                                   node.attr('threshold'), 0.0,
                                   node.output('Out', 0))
 
@@ -151,6 +153,20 @@ class Gelu():
             'Mul', inputs=[x, zero_point_five], outputs=node.output('Out'))
 
 
+@op_mapper('selu')
+class Selu():
+    support_opset_verision_range = (6, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Selu',
+            inputs=node.input('X'),
+            alpha=node.attr('alpha'),
+            gamma=node.attr('scale'),
+            outputs=node.output('Out'))
+
+
 @op_mapper('hard_sigmoid')
 class HardSigmoid():
     support_opset_verison_range = (1, 12)
@@ -175,8 +191,10 @@ class Swish():
     def opset_7(cls, graph, node, **kw):
         beta_node = graph.make_node(
             'Constant',
-            attrs={'dtype': dtypes.ONNX.FLOAT,
-                   'value': [node.attr('beta')]})
+            attrs={
+                'dtype': dtypes.ONNX.FLOAT,
+                'value': [node.attr('beta')]
+            })
         beta_x_node = graph.make_node(
             'Mul', inputs=[node.input('X')[0], beta_node])
         sigmoid_node = graph.make_node('Sigmoid', inputs=[beta_x_node])
@@ -194,16 +212,20 @@ class HardSwish():
     def opset_7(cls, graph, node, **kw):
         scale_node = graph.make_node(
             'Constant',
-            attrs={'dtype': dtypes.ONNX.FLOAT,
-                   'value': node.attr('scale')})
+            attrs={
+                'dtype': dtypes.ONNX.FLOAT,
+                'value': node.attr('scale')
+            })
         offset_node = graph.make_node(
             'Constant',
-            attrs={'dtype': dtypes.ONNX.FLOAT,
-                   'value': node.attr('offset')})
+            attrs={
+                'dtype': dtypes.ONNX.FLOAT,
+                'value': node.attr('offset')
+            })
 
         node0 = graph.make_node('Add', inputs=[node.input('X')[0], offset_node])
-        node1 = mapper_helper.clip_helper(graph, node0,
-                                          node.attr('threshold'), 0.0)
+        node1 = mapper_helper.clip_helper(graph, node0, node.attr('threshold'),
+                                          0.0)
         node2 = graph.make_node('Mul', inputs=[node.input('X')[0], node1])
         node3 = graph.make_node(
             'Div', inputs=[node2, scale_node], outputs=node.output('Out'))

--- a/paddle2onnx/op_mapper/logic.py
+++ b/paddle2onnx/op_mapper/logic.py
@@ -87,6 +87,18 @@ class LogicalAnd():
             outputs=node.output('Out'))
 
 
+@op_mapper('logical_xor')
+class LogicalXor():
+    support_opset_verision_range = (7, 12)
+
+    @classmethod
+    def opset_6(cls, graph, node, **kw):
+        graph.make_node(
+            'Xor',
+            inputs=[node.input('X', 0), node.input('Y', 0)],
+            outputs=node.output('Out'))
+
+
 @op_mapper('less_equal')
 class LessOrEqual():
     support_opset_verison_range = (12, )

--- a/paddle2onnx/op_mapper/logic.py
+++ b/paddle2onnx/op_mapper/logic.py
@@ -89,10 +89,10 @@ class LogicalAnd():
 
 @op_mapper('logical_xor')
 class LogicalXor():
-    support_opset_verision_range = (7, 12)
+    support_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_6(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Xor',
             inputs=[node.input('X', 0), node.input('Y', 0)],

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -438,7 +438,7 @@ class Log10():
     support_opset_verision_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         ten = graph.make_node(
             'Constant', attrs={
                 'dtype': dtypes.ONNX.FLOAT,
@@ -454,7 +454,7 @@ class Log1p():
     support_opset_verision_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         one = graph.make_node(
             'Constant', attrs={
                 'dtype': dtypes.ONNX.FLOAT,

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -151,7 +151,7 @@ class Sin():
     supports_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         graph.make_node(
             'Sin', inputs=node.input('X'), outputs=node.output('Out'))
 
@@ -435,10 +435,10 @@ class Floor():
 
 @op_mapper('log10')
 class Log10():
-    support_opset_verision_range = (7, 12)
+    support_opset_version_range = (1, 12)
 
     @classmethod
-    def opset_7(cls, graph, node, **kw):
+    def opset_1(cls, graph, node, **kw):
         ten = graph.make_node(
             'Constant', attrs={
                 'dtype': dtypes.ONNX.FLOAT,
@@ -451,7 +451,7 @@ class Log10():
 
 @op_mapper('log1p')
 class Log1p():
-    support_opset_verision_range = (7, 12)
+    support_opset_version_range = (7, 12)
 
     @classmethod
     def opset_7(cls, graph, node, **kw):
@@ -470,10 +470,10 @@ class Log1p():
                'reduce_any': 'ReduceMax'
            })
 class ReduceAll():
-    support_opset_verision_range = (6, 12)
+    support_opset_version_range = (6, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_6(cls, graph, node, **kw):
         op_type = kw['mapper_dict'][node.type]
 
         all_node = graph.make_node(
@@ -608,20 +608,20 @@ class ArgMin():
 
 @op_mapper('round')
 class Round():
-    support_opset_verision_range = (11, 12)
+    support_opset_version_range = (11, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_11(cls, graph, node, **kw):
         graph.make_node(
             'Round', inputs=node.input('X'), outputs=node.output('Out'))
 
 
 @op_mapper('rsqrt')
 class Rsqrt():
-    support_opset_verision_range = (6, 12)
+    support_opset_version_range = (6, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_6(cls, graph, node, **kw):
         sqrt_node = graph.make_node('Sqrt', inputs=node.input('X'))
         graph.make_node(
             'Reciprocal', inputs=sqrt_node, outputs=node.output('Out'))
@@ -629,10 +629,10 @@ class Rsqrt():
 
 @op_mapper('sign')
 class Sign():
-    support_opset_verision_range = (9, 12)
+    support_opset_version_range = (9, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_9(cls, graph, node, **kw):
         graph.make_node(
             'Sign', inputs=node.input('X'), outputs=node.output('Out'))
 

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -146,6 +146,16 @@ class Cosh():
             'Cosh', inputs=node.input('X'), outputs=node.output('Out'))
 
 
+@op_mapper('sin')
+class Sin():
+    supports_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Sin', inputs=node.input('X'), outputs=node.output('Out'))
+
+
 @op_mapper(
     [
         'elementwise_add',
@@ -423,6 +433,76 @@ class Floor():
             'Floor', inputs=node.input('X'), outputs=node.output('Out'))
 
 
+@op_mapper('log10')
+class Log10():
+    support_opset_verision_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        ten = graph.make_node(
+            'Constant', attrs={
+                'dtype': dtypes.ONNX.FLOAT,
+                'value': [10]
+            })
+        ln2 = graph.make_node('Log', inputs=[ten])
+        lnx = graph.make_node('Log', inputs=node.input('X'))
+        graph.make_node('Div', inputs=[lnx, ln2], outputs=node.output('Out'))
+
+
+@op_mapper('log1p')
+class Log1p():
+    support_opset_verision_range = (7, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        one = graph.make_node(
+            'Constant', attrs={
+                'dtype': dtypes.ONNX.FLOAT,
+                'value': [1]
+            })
+        add_node = graph.make_node('Add', inputs=[node.input('X', 0), one])
+        graph.make_node('Log', inputs=add_node, outputs=node.output('Out'))
+
+
+@op_mapper(['reduce_all', 'reduce_any'],
+           mapper_dict={
+               'reduce_all': 'ReduceMin',
+               'reduce_any': 'ReduceMax'
+           })
+class ReduceAll():
+    support_opset_verision_range = (6, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        op_type = kw['mapper_dict'][node.type]
+
+        all_node = graph.make_node(
+            'Cast', inputs=[node.input('X', 0)], to=dtypes.ONNX.FLOAT)
+        if node.attr('reduce_all'):
+            flatten_x = graph.make_node('Flatten', inputs=all_node, axis=0)
+            squeeze_node = graph.make_node('Squeeze', inputs=[flatten_x])
+            if node.attr('keep_dim'):
+                unsqueeze_node = graph.make_node(op_type, inputs=squeeze_node)
+                for i in range(len(node.input_shape('X', 0)) - 1):
+                    unsqueeze_node = graph.make_node(
+                        'Unsqueeze', axes=[0], inputs=[unsqueeze_node])
+                graph.make_node(
+                    'Cast',
+                    inputs=[unsqueeze_node],
+                    to=dtypes.ONNX.FLOAT,
+                    outputs=node.output('Out'))
+            else:
+                graph.make_node(
+                    op_type, inputs=squeeze_node, outputs=node.output('Out'))
+        else:
+            graph.make_node(
+                op_type,
+                inputs=all_node,
+                keepdims=node.attr('keep_dim'),
+                axes=node.attr('dim'),
+                outputs=node.output('Out'))
+
+
 @op_mapper(
     ['reduce_mean', 'reduce_sum', 'reduce_min', 'reduce_max', 'reduce_prod'],
     mapper_dict={
@@ -524,6 +604,37 @@ class ArgMin():
                     outputs=node.output('Out'),
                     axis=node.attr('axis'),
                     keepdims=0)
+
+
+@op_mapper('round')
+class Round():
+    support_opset_verision_range = (11, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Round', inputs=node.input('X'), outputs=node.output('Out'))
+
+
+@op_mapper('rsqrt')
+class Rsqrt():
+    support_opset_verision_range = (6, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        sqrt_node = graph.make_node('Sqrt', inputs=node.input('X'))
+        graph.make_node(
+            'Reciprocal', inputs=sqrt_node, outputs=node.output('Out'))
+
+
+@op_mapper('sign')
+class Sign():
+    support_opset_verision_range = (9, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'Sign', inputs=node.input('X'), outputs=node.output('Out'))
 
 
 #

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -435,18 +435,18 @@ class Floor():
 
 @op_mapper('log10')
 class Log10():
-    support_opset_version_range = (1, 12)
+    support_opset_version_range = (7, 12)
 
     @classmethod
-    def opset_1(cls, graph, node, **kw):
+    def opset_7(cls, graph, node, **kw):
         ten = graph.make_node(
             'Constant', attrs={
                 'dtype': dtypes.ONNX.FLOAT,
                 'value': [10]
             })
-        ln2 = graph.make_node('Log', inputs=[ten])
+        ln10 = graph.make_node('Log', inputs=[ten])
         lnx = graph.make_node('Log', inputs=node.input('X'))
-        graph.make_node('Div', inputs=[lnx, ln2], outputs=node.output('Out'))
+        graph.make_node('Div', inputs=[lnx, ln10], outputs=node.output('Out'))
 
 
 @op_mapper('log1p')

--- a/paddle2onnx/op_mapper/nn.py
+++ b/paddle2onnx/op_mapper/nn.py
@@ -213,10 +213,10 @@ class Hardshrink():
 
 @op_mapper('logsigmoid')
 class LogSigmoid():
-    support_opset_verision_range = (1, 12)
+    support_opset_version_range = (1, 12)
 
     @classmethod
-    def opset_6(cls, graph, node, **kw):
+    def opset_1(cls, graph, node, **kw):
         sigmoid_node = graph.make_node('Sigmoid', inputs=node.input('X'))
         graph.make_node('Log', inputs=sigmoid_node, outputs=node.output('Out'))
 

--- a/paddle2onnx/op_mapper/nn.py
+++ b/paddle2onnx/op_mapper/nn.py
@@ -211,6 +211,16 @@ class Hardshrink():
             lambd=node.attr('threshold'))
 
 
+@op_mapper('logsigmoid')
+class LogSigmoid():
+    support_opset_verision_range = (1, 12)
+
+    @classmethod
+    def opset_6(cls, graph, node, **kw):
+        sigmoid_node = graph.make_node('Sigmoid', inputs=node.input('X'))
+        graph.make_node('Log', inputs=sigmoid_node, outputs=node.output('Out'))
+
+
 @op_mapper('norm')
 class Norm():
     support_opset_verison_range = (1, 12)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self, axis=None, keepdim=False):
+        super(Net, self).__init__()
+        self.axis = axis
+        self.keepdim = keepdim
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.all(inputs, axis=self.axis, keepdim=self.keepdim)
+        return x.astype('float32')
+
+
+def test_all_10():
+    """
+    api: paddle.all
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_all_11():
+    """
+    api: paddle.all
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_all_12():
+    """
+    api: paddle.all
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_all_keepdim():
+    """
+    api: paddle.all
+    op version: 12
+    """
+    op = Net(keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_all_axis():
+    """
+    api: paddle.all
+    op version: 12
+    """
+    op = Net(axis=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_all_axis_keepdim():
+    """
+    api: paddle.all
+    op version: 12
+    """
+    op = Net(axis=1, keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'all', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()

--- a/tests/test_any.py
+++ b/tests/test_any.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2021  PaddlePaddle Authors. any Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self, axis=None, keepdim=False):
+        super(Net, self).__init__()
+        self.axis = axis
+        self.keepdim = keepdim
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.any(inputs, axis=self.axis, keepdim=self.keepdim)
+        return x.astype('float32')
+
+
+def test_any_10():
+    """
+    api: paddle.any
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_any_11():
+    """
+    api: paddle.any
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_any_12():
+    """
+    api: paddle.any
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_any_keepdim():
+    """
+    api: paddle.any
+    op version: 12
+    """
+    op = Net(keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_any_axis():
+    """
+    api: paddle.any
+    op version: 12
+    """
+    op = Net(axis=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_any_axis_keepdim():
+    """
+    api: paddle.any
+    op version: 12
+    """
+    op = Net(axis=1, keepdim=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'any', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [4, 3, 10]).astype('bool')))
+    obj.run()

--- a/tests/test_log10.py
+++ b/tests/test_log10.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.log10(inputs)
+        return x
+
+
+def test_log10_7():
+    """
+    api: paddle.log10
+    op version: 7
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log10', [7])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log10_10():
+    """
+    api: paddle.log10
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log10', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log10_11():
+    """
+    api: paddle.log10
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log10', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log10_12():
+    """
+    api: paddle.log10
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log10', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_log1p.py
+++ b/tests/test_log1p.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.log1p(inputs)
+        return x
+
+
+def test_log1p_7():
+    """
+    api: paddle.log1p
+    op version: 7
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log1p', [7])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log1p_10():
+    """
+    api: paddle.log1p
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log1p', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log1p_11():
+    """
+    api: paddle.log1p
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log1p', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_log1p_12():
+    """
+    api: paddle.log1p
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'log1p', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_logical_xor.py
+++ b/tests/test_logical_xor.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs, inputs_):
+        """
+        forward
+        """
+        x = paddle.logical_xor(inputs, inputs_)
+        return x.astype('float32')
+
+
+def test_logical_xor_7():
+    """
+    api: paddle.logical_xor
+    op version: 7
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'logical_xor', [7])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')),
+        paddle.to_tensor(randtool("float", 0, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_logical_xor_11():
+    """
+    api: paddle.logical_xor
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'logical_xor', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')),
+        paddle.to_tensor(randtool("float", 0, 1, [3, 10]).astype('bool')))
+    obj.run()
+
+
+def test_logical_xor_12():
+    """
+    api: paddle.logical_xor
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'logical_xor', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('bool')),
+        paddle.to_tensor(randtool("float", 0, 1, [3, 10]).astype('bool')))
+    obj.run()

--- a/tests/test_nn_LogSigmoid.py
+++ b/tests/test_nn_LogSigmoid.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self._Log_Sigmoid = paddle.nn.LogSigmoid()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = self._Log_Sigmoid(inputs)
+        return x
+
+
+def test_nn_LogSigmoid_9():
+    """
+    api: paddle.nn.LogSigmoid
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_LogSigmoid', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_LogSigmoid_10():
+    """
+    api: paddle.nn.LogSigmoid
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_LogSigmoid', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_LogSigmoid_11():
+    """
+    api: paddle.nn.LogSigmoid
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_LogSigmoid', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_LogSigmoid_12():
+    """
+    api: paddle.nn.LogSigmoid
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_LogSigmoid', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.round(inputs)
+        return x
+
+
+def test_round_11():
+    """
+    api: paddle.round
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'round', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_round_12():
+    """
+    api: paddle.round
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'round', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_rsqrt.py
+++ b/tests/test_rsqrt.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.rsqrt(inputs)
+        return x
+
+
+def test_rsqrt_10():
+    """
+    api: paddle.rsqrt
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'rsqrt', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_rsqrt_11():
+    """
+    api: paddle.rsqrt
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'rsqrt', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_rsqrt_12():
+    """
+    api: paddle.rsqrt
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'rsqrt', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_selu.py
+++ b/tests/test_selu.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self,
+                 alpha=1.6732632423543772848170429916717,
+                 scale=1.0507009873554804934193349852946):
+        super(Net, self).__init__()
+        self.alpha = alpha
+        self.scale = scale
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.nn.functional.selu(
+            inputs, alpha=self.alpha, scale=self.scale)
+        return x
+
+
+def test_nn_functional_selu_10():
+    """
+    api: paddle.nn.functional.selu
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn.functional.selu', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_selu_11():
+    """
+    api: paddle.nn.functional.selu
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn.functional.selu', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_selu_12():
+    """
+    api: paddle.nn.functional.selu
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn.functional.selu', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_selu_scale():
+    """
+    api: paddle.nn.functional.selu
+    op version: 12
+    """
+    op = Net(scale=2)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn.functional.selu', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_selu_alpha():
+    """
+    api: paddle.nn.functional.selu
+    op version: 12
+    """
+    op = Net(alpha=2)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn.functional.selu', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_sign.py
+++ b/tests/test_sign.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.sign(inputs)
+        return x
+
+
+def test_sign_9():
+    """
+    api: paddle.sign
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sign', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_sign_10():
+    """
+    api: paddle.sign
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sign', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_sign_11():
+    """
+    api: paddle.sign
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sign', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_sign_12():
+    """
+    api: paddle.sign
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sign', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_sin.py
+++ b/tests/test_sin.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simplr Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.sin(inputs)
+        return x
+
+
+def test_sin_9():
+    """
+    api: paddle.sin
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sin', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_sin_10():
+    """
+    api: paddle.sin
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sin', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_sin_11():
+    """
+    api: paddle.sin
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sin', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_sin_12():
+    """
+    api: paddle.sin
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'sin', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()


### PR DESCRIPTION
**PR types** ：New features

**Describe：**

Task:  #344

在Paddle2ONNX 新增11个 Paddle 2.0 API 支持

11个API具体为：
- paddle.log10(x, name=None)
- paddle.log1p(x, name=None)
- paddle.logical_xor(x, y, out=None, name=None)
- paddle.nn.LogSigmoid(name=None)
- paddle.all(x, axis=None, keepdim=False, name=None)
- paddle.any(x, axis=None, keepdim=False, name=None)
- paddle.round(x, name=None)
- paddle.rsqrt(x, name=None)
- paddle.nn.functional.selu(x, scale=1.0507, alpha=1.67326, name=None)
- paddle.sign(x, name=None)
- paddle.sin(x, name=None)