### PR TITLE
Support define input shape dict

### DIFF
--- a/paddle2onnx/__init__.py
+++ b/paddle2onnx/__init__.py
@@ -15,5 +15,62 @@ from __future__ import absolute_import
 
 __version__ = "0.8.1"
 
+import paddle
 from .convert import dygraph2onnx, program2onnx
 from .op_mapper import register_op_mapper
+from typing import TypeVar
+
+OP_WITHOUT_KERNEL_SET = {
+    'feed', 'fetch', 'recurrent', 'go', 'rnn_memory_helper_grad',
+    'conditional_block', 'while', 'send', 'recv', 'listen_and_serv',
+    'fl_listen_and_serv', 'ncclInit', 'select', 'checkpoint_notify',
+    'gen_bkcl_id', 'c_gen_bkcl_id', 'gen_nccl_id', 'c_gen_nccl_id',
+    'c_comm_init', 'c_sync_calc_stream', 'c_sync_comm_stream',
+    'queue_generator', 'dequeue', 'enqueue', 'heter_listen_and_serv',
+    'c_wait_comm', 'c_wait_compute', 'c_gen_hccl_id', 'c_comm_init_hccl',
+    'copy_cross_scope'
+}
+
+
+def run_convert(model, input_shape_dict=None, scope=None, opset_version=9):
+    if isinstance(model, paddle.static.Program):
+        if input_shape_dict is not None:
+            for k, v in input_shape_dict.items():
+                model.blocks[0].var(k).desc.set_shape(v)
+            for i in range(len(model.blocks[0].ops)):
+                if model.blocks[0].ops[i].type in OP_WITHOUT_KERNEL_SET:
+                    continue
+                model.blocks[0].ops[i].desc.infer_shape(model.blocks[0].desc)
+        if scope is None:
+            scope = paddle.static.global_scope()
+        input_names = list()
+        output_vars = list()
+        for i in range(len(model.blocks[0].ops)):
+            if model.blocks[0].ops[i].type == "feed":
+                input_names.append(model.blocks[0].ops[i].output("Out")[0])
+            if model.blocks[0].ops[i].type == "fetch":
+                output_vars.append(model.blocks[0].var(model.blocks[0].ops[i]
+                                                       .input("X")[0]))
+        return program2onnx(
+            model,
+            scope,
+            save_file=None,
+            feed_var_names=input_names,
+            target_vars=output_vars,
+            opset_version=opset_version,
+            enable_onnx_checker=True)
+    elif isinstance(model, paddle.jit.TranslatedLayer):
+        if input_shape_dict is not None:
+            for k, v in input_shape_dict.items():
+                model.program().blocks[0].var(k).desc.set_shape(v)
+            for i in range(len(model.program().blocks[0].ops)):
+                if model.program().blocks[0].ops[
+                        i].type in OP_WITHOUT_KERNEL_SET:
+                    continue
+                model.program().blocks[0].ops[i].desc.infer_shape(model.program(
+                ).blocks[0].desc)
+        return dygraph2onnx(model, save_file=None, opset_version=opset_version)
+    else:
+        raise Exception(
+            "Only support model loaded from paddle.static.load_inference_model() or paddle.jit.load()"
+        )

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -58,17 +58,23 @@ def arg_parser():
         default=9,
         help="set onnx opset version to export")
     parser.add_argument(
+       "--input_shape_dict",
+       "-isd",
+       type=_text_type,
+       default="None",
+       help="define input shapes, e.g --input_shape_dict=\"{'image':[1, 3, 608, 608]}\" or" \
+       "--input_shape_dict=\"{'image':[1, 3, 608, 608], 'im_shape': [1, 2], 'scale_factor': [1, 2]}\"")
+    parser.add_argument(
         "--enable_onnx_checker",
         type=ast.literal_eval,
-        default=False,
+        default=True,
         help="whether check onnx model validity, if True, please 'pip install onnx'"
     )
     parser.add_argument(
         "--enable_paddle_fallback",
         type=ast.literal_eval,
         default=False,
-        help="whether use PaddleFallback for custom op, default is False"
-    )
+        help="whether use PaddleFallback for custom op, default is False")
     parser.add_argument(
         "--version",
         "-v",
@@ -84,7 +90,8 @@ def program2onnx(model_dir,
                  params_filename=None,
                  opset_version=9,
                  enable_onnx_checker=False,
-                 operator_export_type="ONNX"):
+                 operator_export_type="ONNX",
+                 input_shape_dict=None):
     try:
         import paddle
     except:
@@ -111,6 +118,25 @@ def program2onnx(model_dir,
             exe,
             model_filename=model_filename,
             params_filename=params_filename)
+
+    OP_WITHOUT_KERNEL_SET = {
+        'feed', 'fetch', 'recurrent', 'go', 'rnn_memory_helper_grad',
+        'conditional_block', 'while', 'send', 'recv', 'listen_and_serv',
+        'fl_listen_and_serv', 'ncclInit', 'select', 'checkpoint_notify',
+        'gen_bkcl_id', 'c_gen_bkcl_id', 'gen_nccl_id', 'c_gen_nccl_id',
+        'c_comm_init', 'c_sync_calc_stream', 'c_sync_comm_stream',
+        'queue_generator', 'dequeue', 'enqueue', 'heter_listen_and_serv',
+        'c_wait_comm', 'c_wait_compute', 'c_gen_hccl_id', 'c_comm_init_hccl',
+        'copy_cross_scope'
+    }
+    if input_shape_dict is not None:
+        for k, v in input_shape_dict.items():
+            program.blocks[0].var(k).desc.set_shape(v)
+        for i in range(len(program.blocks[0].ops)):
+            if program.blocks[0].ops[i].type in OP_WITHOUT_KERNEL_SET:
+                continue
+            program.blocks[0].ops[i].desc.infer_shape(program.blocks[0].desc)
+
     p2o.program2onnx(
         program,
         fluid.global_scope(),
@@ -141,7 +167,9 @@ def main():
 
     assert args.model_dir is not None, "--model_dir should be defined while translating paddle model to onnx"
     assert args.save_file is not None, "--save_file should be defined while translating paddle model to onnx"
-    
+
+    input_shape_dict = eval(args.input_shape_dict)
+
     operator_export_type = "ONNX"
     if args.enable_paddle_fallback:
         operator_export_type = "PaddleFallback"
@@ -152,7 +180,8 @@ def main():
         args.params_filename,
         opset_version=args.opset_version,
         enable_onnx_checker=args.enable_onnx_checker,
-        operator_export_type=operator_export_type)
+        operator_export_type=operator_export_type,
+        input_shape_dict=input_shape_dict)
 
 
 if __name__ == "__main__":

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -36,6 +36,9 @@ def export_onnx(paddle_graph,
 
     onnx_proto = onnx_graph.export_proto(enable_onnx_checker)
 
+    if save_file is None:
+        return onnx_proto
+
     path, _ = os.path.split(save_file)
     if path != '' and not os.path.isdir(path):
         os.makedirs(path)
@@ -77,8 +80,8 @@ def program2onnx(program,
 
         paddle_graph = PaddleGraph.build_from_program(program, feed_var_names,
                                                       target_vars, scope)
-        export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker,
-                    operator_export_type)
+        return export_onnx(paddle_graph, save_file, opset_version,
+                           enable_onnx_checker, operator_export_type)
     else:
         raise TypeError(
             "the input 'program' should be 'Program', but received type is %s."
@@ -159,5 +162,5 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
 
     paddle_graph = PaddleGraph.build_from_dygraph(layer, inner_input_spec,
                                                   output_spec)
-    export_onnx(paddle_graph, save_file, opset_version, enable_onnx_checker,
-                operator_export_type, verbose)
+    return export_onnx(paddle_graph, save_file, opset_version,
+                       enable_onnx_checker, operator_export_type, verbose)

--- a/paddle2onnx/op_mapper/detection/multiclass_nms.py
+++ b/paddle2onnx/op_mapper/detection/multiclass_nms.py
@@ -29,8 +29,10 @@ class MultiClassNMS():
 
     @classmethod
     def opset_10(cls, graph, node, **kw):
-        logging.warning("Operator:{} only supports input[batch_size] == 1.".
-                        format(node.type))
+        if node.input_shape("BBoxes", 0)[0] != 1:
+            logging.warning(
+                "Due to the operator:{}, the converted ONNX model will only supports input[batch_size] == 1.".
+                format(node.type))
         scores = node.input('Scores', 0)
         bboxes = node.input('BBoxes', 0)
         num_class = node.input_shape('Scores', 0)[1]


### PR DESCRIPTION
Support define input shape while convert model to onnx. Also add a API for model conversion.

### Usage
#### 1. Command
```
paddle2onnx --model_dir inference_model \
                       --model_filename model.pdmodel \
                       --params_filename model.pdiparams \
                       --save_file model.onnx \
                       --input_shape_dict "{'x': [1, 3, 224, 224]}"
```

#### 2. API
```
import paddle
import paddle2onnx

model = paddle.jit.load("inference_model/model")
onnx_proto = paddle2onnx.run_convert(model, input_shape_dict={"x": [1, 3, 224, 224]},  opset_version=10)
with open("model.onnx", "wb") as f:
    f.write(onnx_proto.SerializeToString())
```