### PR TITLE
Add eleven operator support and unit testing

### DIFF
--- a/docs/en/op_list.md
+++ b/docs/en/op_list.md
@@ -136,6 +136,7 @@
 | softmax | 1~12 |
 | scale | 1~12 | opset 1~6 limited supported |
 | scatter | 1~15 |
+| scatter_nd_add | 11~12 |
 | sequence_expand | 1~12 |
 | selu | 6~12 |
 | softmax_with_cross_entropy | 12 |

--- a/docs/en/op_list.md
+++ b/docs/en/op_list.md
@@ -14,6 +14,7 @@
 | atan | 7~12 |
 | any | 6~12 |
 | batch_norm | 1~12 |
+| bicubic_interp_v2 | 9~12 |
 | bilinear_interp | 9~12 |
 | bilinear_interp_v2 | 9~12 |
 | bmm | 1~12 |
@@ -59,6 +60,7 @@
 | floor | 1~12 |
 | floor_mod | 7~12 |
 | lod_reset | 1~12 |
+| linear_interp_v2 | 9~12 |
 | lstm | 9~12 |
 | gather | 1~12 |  opset 1~10 limited supported |
 | generate_proposals | 12~ |   |
@@ -95,9 +97,11 @@
 | logical_xor | 1~12 | opset 7~12 limited supported |
 | logsigmoid | 1~12 |
 | logsoftmax | 1~12 |
+| masked_select | 11~12 |
 | matmul | 1~12 |
 | matmul_v2 | 1~12 |
 | mean | 1~12 |
+| meshgrid | 1~12 |
 | mul | 1~12 |
 | muticlass_nms | 10~12 |
 | muticlass_nms2 | 10~12 |
@@ -131,11 +135,13 @@
 | rsqrt | 6~12 |
 | softmax | 1~12 |
 | scale | 1~12 | opset 1~6 limited supported |
+| scatter | 1~15 |
 | sequence_expand | 1~12 |
 | selu | 6~12 |
 | softmax_with_cross_entropy | 12 |
 | softplus | 1~12 |
 | softsign | 1~12 |
+| softshrink | 9~12 |
 | shape | 1~12 |
 | sigmoid | 1~12 |
 | sign | 9~12 |
@@ -151,12 +157,18 @@
 | sum | 1~12 |
 | swish | 1~12 |
 | tanh | 1~12 |
+| tanh_shrink | 7~12 |
+| tan | 8~12 |
+| thresholded_relu | 1~12 |
 | tile | 11~12 |
 | top_k | 11~12 |
 | top_k_v2 | 11~12 |
 | transpose2 | 1~12 |
+| trilinear_interp_v2 | 9~12 |
 | uniform_random | 1~12 |
 | uniform_random_batch_size_like | 1~12 |
+| unique | 11~12 |
 | unsqueeze2 | 1~12 |
+| where | 9~12 |
 | where_index | 9~12 |
 | yolo_box | 9~12 |

--- a/docs/zh/Paddle2ONNX_Development_Guide.md
+++ b/docs/zh/Paddle2ONNX_Development_Guide.md
@@ -90,7 +90,7 @@ Paddle OP的转换需要掌握Paddle OP的原理和使用方式，因此需要�
 
     class Net(paddle.nn.Layer):
     """
-    simplr Net
+    simple Net
     """
 
         def __init__(self):

--- a/docs/zh/op_list.md
+++ b/docs/zh/op_list.md
@@ -136,6 +136,7 @@
 | softmax | 1~12 |
 | scale | 1~12 | opset 1~6 limited supported |
 | scatter | 1~15 |
+| scatter_nd_add | 11~12 |
 | sequence_expand | 1~12 |
 | selu | 6~12 |
 | softmax_with_cross_entropy | 12 |

--- a/docs/zh/op_list.md
+++ b/docs/zh/op_list.md
@@ -14,6 +14,7 @@
 | atan | 7~12 |
 | any | 6~12 |
 | batch_norm | 1~12 |
+| bicubic_interp_v2 | 9~12 |
 | bilinear_interp | 9~12 |
 | bilinear_interp_v2 | 9~12 |
 | bmm | 1~12 |
@@ -59,6 +60,7 @@
 | floor | 1~12 |
 | floor_mod | 7~12 |
 | lod_reset | 1~12 |
+| linear_interp_v2 | 9~12 |
 | lstm | 9~12 |
 | gather | 1~12 |  opset 1~10 limited supported |
 | generate_proposals | 12~ |   |
@@ -95,9 +97,11 @@
 | logical_xor | 1~12 | opset 7~12 limited supported |
 | logsigmoid | 1~12 |
 | logsoftmax | 1~12 |
+| masked_select | 11~12 |
 | matmul | 1~12 |
 | matmul_v2 | 1~12 |
 | mean | 1~12 |
+| meshgrid | 1~12 |
 | mul | 1~12 |
 | muticlass_nms | 10~12 |
 | muticlass_nms2 | 10~12 |
@@ -131,11 +135,13 @@
 | rsqrt | 6~12 |
 | softmax | 1~12 |
 | scale | 1~12 | opset 1~6 limited supported |
+| scatter | 1~15 |
 | sequence_expand | 1~12 |
 | selu | 6~12 |
 | softmax_with_cross_entropy | 12 |
 | softplus | 1~12 |
 | softsign | 1~12 |
+| softshrink | 9~12 |
 | shape | 1~12 |
 | sigmoid | 1~12 |
 | sign | 9~12 |
@@ -151,12 +157,18 @@
 | sum | 1~12 |
 | swish | 1~12 |
 | tanh | 1~12 |
+| tanh_shrink | 7~12 |
+| tan | 8~12 |
+| thresholded_relu | 1~12 |
 | tile | 11~12 |
 | top_k_v2 | 11~12 |
 | top_k | 11~12 |
 | transpose2 | 1~12 |
+| trilinear_interp_v2 | 9~12 |
 | uniform_random | 1~12 |
 | uniform_random_batch_size_like | 1~12 |
+| unique | 11~12 |
 | unsqueeze2 | 1~12 |
+| where | 9~12 |
 | where_index | 9~12 |
 | yolo_box | 9~12 |

--- a/paddle2onnx/op_mapper/math.py
+++ b/paddle2onnx/op_mapper/math.py
@@ -169,6 +169,16 @@ class Atan():
             'Atan', inputs=node.input('X'), outputs=node.output('Out'))
 
 
+@op_mapper('tan')
+class Tan():
+    supports_opset_version_range = (8, 12)
+
+    @classmethod
+    def opset_8(cls, graph, node, **kw):
+        graph.make_node(
+            'Tan', inputs=node.input('X'), outputs=node.output('Out'))
+
+
 @op_mapper('ceil')
 class Ceil():
     supports_opset_version_range = (6, 12)

--- a/paddle2onnx/op_mapper/nn.py
+++ b/paddle2onnx/op_mapper/nn.py
@@ -244,6 +244,36 @@ class Norm():
             axis=node.attr('axis'))
 
 
+@op_mapper('softshrink')
+class SoftShrink():
+    support_opset_version_range = (9, 12)
+
+    @classmethod
+    def opset_9(cls, graph, node, **kw):
+        graph.make_node(
+            'Shrink',
+            inputs=node.input('X'),
+            bias=node.attr('lambda'),
+            lambd=node.attr('lambda'),
+            outputs=node.output('Out'))
+
+
+@op_mapper('tanh_shrink')
+class TanhShrink():
+    support_opset_version_range = (7, 12)
+
+    @classmethod
+    def opset_7(cls, graph, node, **kw):
+        tanh_node = graph.make_node(
+            'Tanh',
+            inputs=node.input('X', 0),
+        )
+        graph.make_node(
+            'Sub',
+            inputs=[node.input('X', 0), tanh_node],
+            outputs=node.output('Out'))
+
+
 @op_mapper('log_softmax')
 class LogSoftmax():
     support_opset_version_range = (1, 12)
@@ -656,3 +686,16 @@ class RNN():
                     'Reshape',
                     inputs=[prev_output, prev_shape],
                     outputs=output_y)
+
+
+@op_mapper('thresholded_relu')
+class ThresholdedRelu():
+    support_opset_version_range = (1, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        graph.make_node(
+            'ThresholdedRelu',
+            inputs=node.input('X'),
+            alpha=node.attr('threshold'),
+            outputs=node.output('Out'))

--- a/paddle2onnx/op_mapper/op_mapper.py
+++ b/paddle2onnx/op_mapper/op_mapper.py
@@ -91,6 +91,7 @@ class OpMapper(object):
                         OpMapper.OPSETS[op] = {}
                     opset_dict = OpMapper.OPSETS[op]
                     opset_dict[version] = (v, self.kwargs)
+        return cls
 
     @staticmethod
     def mapping(graph, node, operator_export_type="ONNX"):

--- a/paddle2onnx/op_mapper/search.py
+++ b/paddle2onnx/op_mapper/search.py
@@ -160,3 +160,62 @@ class IndexSelect():
                     node.input('Index', 0)],
             axis=node.attr('dim'),
             outputs=node.output('Out'))
+
+
+@op_mapper('unique')
+class Unique():
+    support_opset_version_range = (11, 12)
+
+    @classmethod
+    def opset_11(cls, graph, node, **kw):
+        if node.attr('axis') == []:
+            graph.make_node(
+                'Unique',
+                inputs=node.input('X'),
+                outputs=[
+                    node.output('Out', 0),
+                    node.output('Indices', 0),
+                    node.output('Index', 0),
+                    node.output('Counts', 0)
+                ])
+        else:
+            graph.make_node(
+                'Unique',
+                inputs=node.input('X'),
+                axis=node.attr('axis')[0],
+                outputs=[
+                    node.output('Out', 0),
+                    node.output('Indices', 0),
+                    node.output('Index', 0),
+                    node.output('Counts', 0)
+                ])
+
+
+@op_mapper('where')
+class Where():
+    support_opset_version_range = (9, 12)
+
+    @classmethod
+    def opset_9(cls, graph, node, **kw):
+        graph.make_node(
+            'Where',
+            inputs=[
+                node.input('Condition', 0),
+                node.input('X', 0),
+                node.input('Y', 0)
+            ],
+            outputs=node.output('Out'))
+
+
+@op_mapper('masked_select')
+class MaskSelect():
+    support_opset_version_range = (11, 12)
+
+    @classmethod
+    def opset_11(cls, graph, node, **kw):
+        index = graph.make_node('NonZero', inputs=node.input('Mask', 0))
+        index = graph.make_node('Transpose', inputs=[index], perm=[1, 0])
+        graph.make_node(
+            'GatherND',
+            inputs=[node.input('X', 0), index],
+            outputs=node.output('Y'))

--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -1307,6 +1307,30 @@ class Scatter():
                 outputs=node.output('Out'))
 
 
+@op_mapper('scatter_nd_add')
+class ScatterndAdd():
+    support_opset_version_range = (11, 12)
+
+    @classmethod
+    def opset_11(cls, graph, node, **kw):
+        shape = graph.make_node('Shape', inputs=node.input('X', 0))
+        zero_like_node = graph.make_node('ConstantOfShape',
+                                         inputs=[shape],
+                                         dims=[1],
+                                         dtype=dtypes.ONNX.FLOAT,
+                                         value=[0])
+        add_node = graph.make_node(
+            'ScatterND',
+            inputs=[
+                zero_like_node,
+                node.input('Index', 0),
+                node.input('Updates', 0)
+            ],
+        )
+        graph.make_node('Add',
+                        inputs=[node.input('X', 0), add_node],
+                        outputs=node.output('Out'))
+
 @op_mapper('meshgrid')
 class Meshgrid():
     support_opset_version_range = (1, 12)

--- a/tests/test_mask_select.py
+++ b/tests/test_mask_select.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs, mask):
+        """
+        forward
+        """
+        x = paddle.masked_select(inputs, mask)
+        return x
+
+
+def test_mask_select_11():
+    """
+    api: paddle.mask_select
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'mask_select', [11])
+    obj.set_input_data("input_data",
+                       paddle.to_tensor([10, 4, 5, 6]).astype('float32'),
+                       paddle.to_tensor([1, 0, 1, 0]).astype('bool'))
+    obj.run()
+
+
+def test_mask_select_12():
+    """
+    api: paddle.mask_select
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'mask_select', [12])
+    obj.set_input_data("input_data",
+                       paddle.to_tensor([10, 4, 5, 6]).astype('float32'),
+                       paddle.to_tensor([1, 0, 1, 0]).astype('bool'))
+    obj.run()

--- a/tests/test_meshgrid.py
+++ b/tests/test_meshgrid.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs, _inputs):
+        """
+        forward
+        """
+        x, y = paddle.meshgrid([inputs, _inputs])
+        return x + y
+
+
+def test_meshgrid_base():
+    """
+    api: paddle.meshgrid
+    op version: 11, 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'meshgrid', [11, 12])
+    obj.set_input_data("input_data",
+                       paddle.to_tensor([1, 2, 3]).astype('float32'),
+                       paddle.to_tensor([4, 5, 6]).astype('float32'))
+    obj.run()
+
+
+def test_meshgrid_unlikeSize():
+    """
+    api: paddle.meshgrid
+    op version: 11, 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'meshgrid', [11, 12])
+    obj.set_input_data("input_data",
+                       paddle.to_tensor([1, 2, 3]).astype('float32'),
+                       paddle.to_tensor([5, 6]).astype('float32'))
+    obj.run()
+
+
+class Net_3(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net_3, self).__init__()
+
+    def forward(self, inputs, _inputs, _input):
+        """
+        forward
+        """
+        x, y, z = paddle.meshgrid([inputs, _inputs, _input])
+        return x + y + z
+
+
+def test_meshgrid_3():
+    """
+    api: paddle.meshgrid
+    op version: 11, 12
+    """
+    op = Net_3()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'meshgrid', [11, 12])
+    obj.set_input_data("input_data",
+                       paddle.to_tensor([1, 2, 3]).astype('float32'),
+                       paddle.to_tensor([5, 6]).astype('float32'),
+                       paddle.to_tensor([1, 2, 3, 4]).astype('float32'))
+    obj.run()

--- a/tests/test_nn_Functional_interpolate.py
+++ b/tests/test_nn_Functional_interpolate.py
@@ -1,0 +1,509 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.nn as nn
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self,
+                 size=None,
+                 scale_factor=None,
+                 mode='nearest',
+                 align_corners=False,
+                 align_mode=0,
+                 data_format='NCHW'):
+        super(Net, self).__init__()
+        self.size = size
+        self.scale_factor = scale_factor
+        self.mode = mode
+        self.align_corners = align_corners
+        self.align_mode = align_mode
+        self.data_format = data_format
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = nn.functional.interpolate(
+            x=inputs,
+            size=self.size,
+            scale_factor=self.scale_factor,
+            mode=self.mode,
+            align_corners=self.align_corners,
+            align_mode=self.align_mode,
+            data_format=self.data_format)
+        return x
+
+
+def test_nn_functional_interpolate_nearest_scale_factor_float():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(scale_factor=1.5)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 3, 6, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_nearest_scale_factor_list():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(scale_factor=[1, 2])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 3, 6, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_nearest_scale_factor_tuple():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(scale_factor=(1, 2))
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 3, 6, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_nearest_size():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(size=[4, 11])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_nearest_date_format():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(size=[4, 12], data_format='NHWC')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_linear_scale_factor_float():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='linear', scale_factor=1.3, data_format='NCW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 6, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_linear_date_format():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='linear', scale_factor=1.3, data_format='NWC')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 6, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_linear_align_corners():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(
+        mode='linear', scale_factor=1.5, data_format='NWC', align_corners=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_linear_size():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='linear', size=[5], data_format='NWC', align_corners=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_scale_factor_float():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', scale_factor=1.5)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_scale_factor_list():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', scale_factor=[1.5, 2])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_size():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', size=[4, 10])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_align_corners():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', scale_factor=1.5, align_corners=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_alige_mode():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', scale_factor=1.5, align_mode=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bilinear_data_format():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bilinear', scale_factor=1.5, data_format='NHWC')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_scale_factor_float():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='trilinear', scale_factor=1.5, data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 4]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_scale_factor_list():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(
+        mode='trilinear', scale_factor=[1.5, 1.5, 1.5], data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 4]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_scale_factor_tuple():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(
+        mode='trilinear', scale_factor=(1.5, 1.5, 1.5), data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_size():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='trilinear', size=[4, 10, 10], data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_align_corners():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(
+        mode='trilinear',
+        scale_factor=1.5,
+        align_corners=True,
+        data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_align_mode():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(
+        mode='trilinear', scale_factor=1.5, align_mode=1, data_format='NCDHW')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_trilinear_data_format():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='trilinear', scale_factor=1.5, data_format='NDHWC')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_scale_factor_float():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', scale_factor=1.5)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_scale_factor_list():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', scale_factor=[1.5, 1.5])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_scale_factor_tuple():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', scale_factor=(1.5, 1.5))
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_size():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', size=[5, 5])
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_align_corners():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', scale_factor=1.5, align_corners=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_interpolate_bicubic_data_format():
+    """
+    api: paddle.nn.functional.interpolate
+    op version: 11
+    """
+    op = Net(mode='bicubic', scale_factor=1.5, data_format='NHWC')
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_interpolate', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(
+            randtool("float", -1, 1, [1, 2, 2, 5]).astype('float32')))
+    obj.run()

--- a/tests/test_nn_Functional_interpolate.py
+++ b/tests/test_nn_Functional_interpolate.py
@@ -138,7 +138,7 @@ def test_nn_functional_interpolate_linear_scale_factor_float():
     api: paddle.nn.functional.interpolate
     op version: 11
     """
-    op = Net(mode='linear', scale_factor=1.3, data_format='NCW')
+    op = Net(mode='linear', scale_factor=1.5, data_format='NCW')
     op.eval()
     # net, name, ver_list, delta=1e-6, rtol=1e-5
     obj = APIOnnx(op, 'nn_functional_interpolate', [11])
@@ -154,7 +154,7 @@ def test_nn_functional_interpolate_linear_date_format():
     api: paddle.nn.functional.interpolate
     op version: 11
     """
-    op = Net(mode='linear', scale_factor=1.3, data_format='NWC')
+    op = Net(mode='linear', scale_factor=1.5, data_format='NWC')
     op.eval()
     # net, name, ver_list, delta=1e-6, rtol=1e-5
     obj = APIOnnx(op, 'nn_functional_interpolate', [11])
@@ -171,7 +171,7 @@ def test_nn_functional_interpolate_linear_align_corners():
     op version: 11
     """
     op = Net(
-        mode='linear', scale_factor=1.5, data_format='NWC', align_corners=True)
+        mode='linear', scale_factor=1.5, data_format='NCW', align_corners=True)
     op.eval()
     # net, name, ver_list, delta=1e-6, rtol=1e-5
     obj = APIOnnx(op, 'nn_functional_interpolate', [11])
@@ -187,7 +187,7 @@ def test_nn_functional_interpolate_linear_size():
     api: paddle.nn.functional.interpolate
     op version: 11
     """
-    op = Net(mode='linear', size=[5], data_format='NWC', align_corners=True)
+    op = Net(mode='linear', size=[5], data_format='NCW')
     op.eval()
     # net, name, ver_list, delta=1e-6, rtol=1e-5
     obj = APIOnnx(op, 'nn_functional_interpolate', [11])

--- a/tests/test_nn_Functional_thresholded.py
+++ b/tests/test_nn_Functional_thresholded.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.nn as nn
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self, threshold=1):
+        super(Net, self).__init__()
+        self.threshold = threshold
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = nn.functional.thresholded_relu(inputs, threshold=self.threshold)
+        return x
+
+
+def test_nn_functional_thresholded_relu_10():
+    """
+    api: paddle.nn.thresholded_relu
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_thresholded_relu', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_thresholded_relu_11():
+    """
+    api: paddle.nn.thresholded_relu
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_thresholded_relu', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_thresholded_relu_12():
+    """
+    api: paddle.nn.thresholded_relu
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_thresholded_relu', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_functional_thresholded_relu_threshold():
+    """
+    api: paddle.nn.thresholded_relu
+    op version: 12
+    """
+    op = Net(threshold=2)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_functional_thresholded_relu', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_nn_TanhShrink.py
+++ b/tests/test_nn_TanhShrink.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+        self._tanhshrink = paddle.nn.Tanhshrink()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = self._tanhshrink(inputs)
+        return x
+
+
+def test_nn_tanhshrink_9():
+    """
+    api: paddle.nn.tanhshrink
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_tanhshrink', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_tanhshrink_10():
+    """
+    api: paddle.nn.tanhshrink
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_tanhshrink', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_tanhshrink_11():
+    """
+    api: paddle.nn.tanhshrink
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_tanhshrink', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_nn_tanhshrink_12():
+    """
+    api: paddle.nn.tanhshrink
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'nn_tanhshrink', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self, overwrite=True):
+        super(Net, self).__init__()
+        self.overwrite = overwrite
+
+    def forward(self, inputs, _index, _updates):
+        """
+        forward
+        """
+        x = paddle.scatter(inputs, _index, _updates, overwrite=self.overwrite)
+        return x
+
+
+def test_scatter_11():
+    """
+    api: paddle.scatter
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
+    obj.run()
+
+
+def test_scatter_12():
+    """
+    api: paddle.scatter
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
+    obj.run()
+
+
+def test_scatter_14():
+    """
+    api: paddle.scatter
+    op version: 14
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter', [14])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
+    obj.run()
+
+
+def test_scatter_15():
+    """
+    api: paddle.scatter
+    op version: 15
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter', [15])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
+    obj.run()
+
+
+# def test_scatter_overwrite():
+#     """
+#     api: paddle.scatter
+#     op version: 16
+#     """
+#     op = Net(overwrite=False)
+#     op.eval()
+#     # net, name, ver_list, delta=1e-6, rtol=1e-5
+#     obj = APIOnnx(op, 'scatter', [16])
+#     obj.set_input_data(
+#         "input_data",
+#         paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+#         paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
+#         paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
+#     obj.run()

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -102,18 +102,18 @@ def test_scatter_15():
     obj.run()
 
 
-# def test_scatter_overwrite():
-#     """
-#     api: paddle.scatter
-#     op version: 16
-#     """
-#     op = Net(overwrite=False)
-#     op.eval()
-#     # net, name, ver_list, delta=1e-6, rtol=1e-5
-#     obj = APIOnnx(op, 'scatter', [16])
-#     obj.set_input_data(
-#         "input_data",
-#         paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
-#         paddle.to_tensor([2, 1, 0, 2]).astype('int64'),
-#         paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]]).astype('float32'))
-#     obj.run()
+def test_scatter_overwrite():
+    """
+    api: paddle.scatter
+    op version: 16
+    """
+    op = Net(overwrite=False)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter', [15])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([2, 1, 0]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'))
+    obj.run()

--- a/tests/test_scatter_nd_add.py
+++ b/tests/test_scatter_nd_add.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs, _index, _updates):
+        """
+        forward
+        """
+        x = paddle.scatter_nd_add(inputs, _index, _updates)
+        return x
+
+
+def test_scatter_nd_add_11():
+    """
+    api: paddle.scatter_nd_add
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter_nd_add', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([[2], [1], [0]]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'))
+    obj.run()
+
+
+def test_scatter_nd_add_12():
+    """
+    api: paddle.scatter_nd_add
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'scatter_nd_add', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'),
+        paddle.to_tensor([[2], [1], [0]]).astype('int64'),
+        paddle.to_tensor([[1, 1], [2, 2], [3, 3]]).astype('float32'))
+    obj.run()

--- a/tests/test_softshrink.py
+++ b/tests/test_softshrink.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.nn as nn
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self, threshold=0.5):
+        super(Net, self).__init__()
+        self.threshold = threshold
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = nn.functional.softshrink(inputs, threshold=self.threshold)
+        return x
+
+
+def test_softshrink_9():
+    """
+    api: paddle.softshrink
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'softshrink', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_softshrink_10():
+    """
+    api: paddle.softshrink
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'softshrink', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_softshrink_11():
+    """
+    api: paddle.softshrink
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'softshrink', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_softshrink_12():
+    """
+    api: paddle.softshrink
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'softshrink', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_softshrink_threshold():
+    """
+    api: paddle.softshrink
+    op version: 12
+    """
+    op = Net(threshold=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'softshrink', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_tan.py
+++ b/tests/test_tan.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.tan(inputs)
+        return x
+
+
+def test_tan_8():
+    """
+    api: paddle.tan
+    op version: 8
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'tan', [8])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_tan_10():
+    """
+    api: paddle.tan
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'tan', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_tan_11():
+    """
+    api: paddle.tan
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'tan', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()
+
+
+def test_tan_12():
+    """
+    api: paddle.tan
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'tan', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 3, 3]).astype('float32')))
+    obj.run()

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self, axis=None):
+        super(Net, self).__init__()
+        self.axis = axis
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.unique(inputs, axis=self.axis)
+
+        return x
+
+
+def test_unique_11():
+    """
+    api: paddle.unique
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_12():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_axis():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net(axis=1)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+class Net_mult_2(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self,
+                 return_index=False,
+                 return_inverse=False,
+                 return_counts=False,
+                 axis=None):
+        super(Net_mult_2, self).__init__()
+        self.return_index = return_index
+        self.return_inverse = return_inverse
+        self.return_counts = return_counts
+        self.axis = axis
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x, y = paddle.unique(
+            inputs,
+            axis=self.axis,
+            return_index=self.return_index,
+            return_inverse=self.return_inverse,
+            return_counts=self.return_counts)
+
+        return x + y
+
+
+def test_unique_return_index():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_2(return_index=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_return_inverse():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_2(return_inverse=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_return_counts():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_2(return_counts=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+class Net_mult_3(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self,
+                 return_index=False,
+                 return_inverse=False,
+                 return_counts=False,
+                 axis=None):
+        super(Net_mult_3, self).__init__()
+        self.return_index = return_index
+        self.return_inverse = return_inverse
+        self.return_counts = return_counts
+        self.axis = axis
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x, y, z = paddle.unique(
+            inputs,
+            axis=self.axis,
+            return_index=self.return_index,
+            return_inverse=self.return_inverse,
+            return_counts=self.return_counts)
+
+        return x + y + z
+
+
+def test_unique_return_index_inverse():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_3(return_index=True, return_inverse=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_return_index_counts():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_3(return_index=True, return_counts=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_unique_return_inverse_counts():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_3(return_inverse=True, return_counts=True)
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()
+
+
+class Net_mult_all(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self, axis=None):
+        super(Net_mult_all, self).__init__()
+        self.axis = axis
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x, y, z, w = paddle.unique(
+            inputs,
+            axis=self.axis,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True)
+
+        return x + y + z + w
+
+
+def test_unique_return_all():
+    """
+    api: paddle.unique
+    op version: 12
+    """
+    op = Net_mult_all()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'unique', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')))
+    obj.run()

--- a/tests/test_where.py
+++ b/tests/test_where.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from onnxbase import APIOnnx
+from onnxbase import randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs, _inputs):
+        """
+        forward
+        """
+        x = paddle.where(inputs < _inputs, inputs, _inputs)
+        return x
+
+
+def test_where_9():
+    """
+    api: paddle.where
+    op version: 9
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'where', [9])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')),
+        paddle.to_tensor(randtool("float", -1, 2, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_where_10():
+    """
+    api: paddle.where
+    op version: 10
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'where', [10])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')),
+        paddle.to_tensor(randtool("float", -1, 2, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_where_11():
+    """
+    api: paddle.where
+    op version: 11
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'where', [11])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')),
+        paddle.to_tensor(randtool("float", -1, 2, [3, 10]).astype('float32')))
+    obj.run()
+
+
+def test_where_12():
+    """
+    api: paddle.where
+    op version: 12
+    """
+    op = Net()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, 'where', [12])
+    obj.set_input_data(
+        "input_data",
+        paddle.to_tensor(randtool("float", -1, 1, [3, 10]).astype('float32')),
+        paddle.to_tensor(randtool("float", -1, 2, [3, 10]).astype('float32')))
+    obj.run()


### PR DESCRIPTION
11个 API 具体为：

paddle.nn.functional.interpolate(x, size=None, scale_factor=None, mode='nearest', align_corners=False, align_mode=0, data_format='NCHW', name=None)

paddle.nn.functional.softshrink(x, threshold=0.5, name=None)

paddle.tan(x, name=None)

paddle.nn.Tanhshrink(name=None)

paddle.nn.functional.thresholded_relu(x, threshold=1.0, name=None)

paddle.unique(x, return_index=False, return_inverse=False, return_counts=False, axis=None, dtype='int64', name=None)

paddle.where(condition, x, y, name=None)

paddle.scatter(x, index, updates, overwrite=True, name=None)

paddle.scatter_nd_add(x, index, updates, name=None)

paddle.meshgrid(*args, **kargs)

paddle.masked_select(x, mask, name=None)