### PR TITLE
Add gaussian_random support and test cases

### DIFF
--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -1221,10 +1221,10 @@ class GaussianRandom():
         shape = node.output_shape('Out', 0)
         graph.make_node(
             'RandomNormal',
+            dtype=dtypes.DTYPE_PADDLE_ONNX_MAP[node.attr('dtype')],
             outputs=node.output('Out'),
             mean=node.attr('mean'),
-            dtype=dtypes.DTYPE_PADDLE_ONNX_MAP[node.attr('dtype')],
-            seed=float(node.attr('seed')),
+            scale=node.attr('std'),
             shape=shape
         )
 

--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -1212,6 +1212,23 @@ class UniformRandom():
             shape=shape)
 
 
+@op_mapper('gaussian_random')
+class GaussianRandom():
+    support_opset_version_range = (1, 12)
+
+    @classmethod
+    def opset_1(cls, graph, node, **kw):
+        shape = node.output_shape('Out', 0)
+        graph.make_node(
+            'RandomNormal',
+            outputs=node.output('Out'),
+            mean=node.attr('mean'),
+            dtype=dtypes.DTYPE_PADDLE_ONNX_MAP[node.attr('dtype')],
+            seed=float(node.attr('seed')),
+            shape=shape
+        )
+
+
 @op_mapper(
     [
         'bilinear_interp', 'nearest_interp', 'bilinear_interp_v2',

--- a/tests/test_randn.py
+++ b/tests/test_randn.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import paddle
+
+from onnxbase import APIOnnx, randtool
+
+
+class Net(paddle.nn.Layer):
+    """
+    simple Net
+    """
+
+    def __init__(self):
+        super(Net, self).__init__()
+
+    def forward(self, inputs):
+        """
+        forward
+        """
+        x = paddle.randn([3, 10])
+        x = paddle.add(x, inputs)
+        return x
+
+
+# def test_gaussian_random_9():
+#     """
+#     api: paddle.randn
+#     op version: 9
+#     """
+#     op = Net()
+#     op.eval()
+#     # net, name, ver_list, delta=1e-6, rtol=1e-5
+#     obj = APIOnnx(op, 'randn', [9])
+#     obj.set_input_data("input_data",
+#                        paddle.to_tensor(
+#                            randtool("float", -1, 1, [3, 10]).astype('float32')))
+#     obj.run()
+
+
+# def test_gaussian_random_10():
+#     """
+#     api: paddle.randn
+#     op version: 10
+#     """
+#     op = Net()
+#     op.eval()
+#     # net, name, ver_list, delta=1e-6, rtol=1e-5
+#     obj = APIOnnx(op, 'randn', [10])
+#     obj.set_input_data("input_data",
+#                        paddle.to_tensor(
+#                            randtool("float", -1, 1, [3, 10]).astype('float32')))
+#     obj.run()
+
+
+# def test_gaussian_random_11():
+#     """
+#     api: paddle.randn
+#     op version: 11
+#     """
+#     op = Net()
+#     op.eval()
+#     # net, name, ver_list, delta=1e-6, rtol=1e-5
+#     obj = APIOnnx(op, 'randn', [11])
+#     obj.set_input_data("input_data",
+#                        paddle.to_tensor(
+#                            randtool("float", -1, 1, [3, 10]).astype('float32')))
+#     obj.run()
+
+
+# def test_gaussian_random_12():
+#     """
+#     api: paddle.randn
+#     op version: 12
+#     """
+#     op = Net()
+#     op.eval()
+#     # net, name, ver_list, delta=1e-6, rtol=1e-5
+#     obj = APIOnnx(op, 'randn', [12])
+#     obj.set_input_data("input_data",
+#                        paddle.to_tensor(
+#                            randtool("float", -1, 1, [3, 10]).astype('float32')))
+#     obj.run()


### PR DESCRIPTION
- 在尝试转换PaddleSpeech中的`pwgan_csmsc.pdmodel`时，遇到
```python
There's 1 ops are not supported yet
=========== gaussian_random ===========
```
- 尝试自己实现了这个OP，成功转换了上述模型，但是用ONNXRuntime加载时，却报错如下：
```python
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /data/home/xxx/PaddleSpeech/examples/csmsc/tts2/exp/default/inference/onnx/pwgan_csmsc.onnx failed:Node (RandomNormal_0) Op (RandomNormal) [ShapeInferenceError] Negative values are not allowed in a shape specification
```
- 目前尚不知怎么修复这个问题

- 如果实现的有啥问题，还请多多指教