### PR TITLE
Fix Split OP

### DIFF
--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -198,6 +198,24 @@ class Split():
                 outputs=node.output('Out'),
                 axis=node.attr('axis'))
 
+    @classmethod
+    def opset_13(cls, graph, node, **kw):
+        sections = node.attr('sections')
+        if len(sections) > 0:
+            const_node = graph.make_node(
+                'Constant', dtype=dtypes.ONNX.INT64, value=sections)
+            graph.make_node(
+                'Split',
+                inputs=node.input('X') + [const_node],
+                outputs=node.output('Out'),
+                axis=node.attr('axis'))
+        else:
+            graph.make_node(
+                'Split',
+                inputs=node.input('X'),
+                outputs=node.output('Out'),
+                axis=node.attr('axis'))
+
 
 @op_mapper(['slice', 'strided_slice'])
 class Slice():


### PR DESCRIPTION
1. 修复当Opset Version >= 13时，Split OP的split输入要求为tensor的问题