### PR TITLE
remove approximate parameter assert for gelu

### DIFF
--- a/paddle2onnx/op_mapper/activation.py
+++ b/paddle2onnx/op_mapper/activation.py
@@ -118,8 +118,6 @@ class Gelu():
 
     @classmethod
     def opset_9(cls, graph, node, **kw):
-        if node.attr('approximate'):
-            raise Exception("Not support approximate is True.")
         input = node.input('X', 0)
         if node.input_dtype('X', 0) == paddle.float64:
             input = graph.make_node(


### PR DESCRIPTION
In paddle, we use `Approximate` to choose a high performance implementation for `Gelu`, sometimes it will cause some difference with the normal `Gelu`, but it's acceptable