### PR TITLE
Fixed flatten_contiguous_range bug

### DIFF
--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -1017,7 +1017,7 @@ class FlattenContiguousRange():
         if start_axis == 0 and end_axis == dims - 1:
             final_shape = graph.make_node(
                 'Constant', value=[-1], dtype=dtypes.ONNX.INT64)
-        elif start_axis == 0 and end_axis < dims - 1:
+        elif start_axis == 0:
             slice_end = mapper_helper.slice_helper(
                 graph, shape_node, axes=[0], starts=[end_axis + 1],
                 ends=[dims])
@@ -1026,7 +1026,7 @@ class FlattenContiguousRange():
                     'Constant', value=[-1], dtype=dtypes.ONNX.INT64), slice_end
             ]
             final_shape = graph.make_node('Concat', inputs=slices, axis=0)
-        elif start_axis > 0 and end_axis == dims - 1:
+        elif end_axis == dims - 1:
             slice_start = mapper_helper.slice_helper(
                 graph, shape_node, axes=[0], starts=[0], ends=[start_axis])
             slices = [
@@ -1034,7 +1034,7 @@ class FlattenContiguousRange():
                     'Constant', value=[-1], dtype=dtypes.ONNX.INT64)
             ]
             final_shape = graph.make_node('Concat', inputs=slices, axis=0)
-        elif start_axis > 0 and end_axis < dims - 1:
+        else:
             slice_start = mapper_helper.slice_helper(
                 graph, shape_node, axes=[0], starts=[0], ends=[start_axis])
             slice_end = mapper_helper.slice_helper(

--- a/paddle2onnx/op_mapper/tensor.py
+++ b/paddle2onnx/op_mapper/tensor.py
@@ -1010,24 +1010,41 @@ class FlattenContiguousRange():
         start_axis = node.attr('start_axis')
         end_axis = node.attr('stop_axis')
         shape_node = graph.make_node('Shape', inputs=node.input('X'))
-        if end_axis < dims - 1:
-            slice1 = mapper_helper.slice_helper(
-                graph, shape_node, axes=[0], starts=[0], ends=[start_axis])
-            slice3 = mapper_helper.slice_helper(
+        if start_axis < 0:
+            start_axis += dims
+        if end_axis < 0:
+            end_axis += dims
+        if start_axis == 0 and end_axis == dims - 1:
+            final_shape = graph.make_node(
+                'Constant', value=[-1], dtype=dtypes.ONNX.INT64)
+        elif start_axis == 0 and end_axis < dims - 1:
+            slice_end = mapper_helper.slice_helper(
                 graph, shape_node, axes=[0], starts=[end_axis + 1],
                 ends=[dims])
             slices = [
-                slice1, graph.make_node(
-                    'Constant', value=[-1], dtype=dtypes.ONNX.INT64), slice3
+                graph.make_node(
+                    'Constant', value=[-1], dtype=dtypes.ONNX.INT64), slice_end
             ]
-        else:
-            slice1 = mapper_helper.slice_helper(
+            final_shape = graph.make_node('Concat', inputs=slices, axis=0)
+        elif start_axis > 0 and end_axis == dims - 1:
+            slice_start = mapper_helper.slice_helper(
                 graph, shape_node, axes=[0], starts=[0], ends=[start_axis])
             slices = [
-                slice1, graph.make_node(
+                slice_start, graph.make_node(
                     'Constant', value=[-1], dtype=dtypes.ONNX.INT64)
             ]
-        final_shape = graph.make_node('Concat', inputs=slices, axis=0)
+            final_shape = graph.make_node('Concat', inputs=slices, axis=0)
+        elif start_axis > 0 and end_axis < dims - 1:
+            slice_start = mapper_helper.slice_helper(
+                graph, shape_node, axes=[0], starts=[0], ends=[start_axis])
+            slice_end = mapper_helper.slice_helper(
+                graph, shape_node, axes=[0], starts=[end_axis + 1],
+                ends=[dims])
+            slices = [
+                slice_start, graph.make_node(
+                    'Constant', value=[-1], dtype=dtypes.ONNX.INT64), slice_end
+            ]
+            final_shape = graph.make_node('Concat', inputs=slices, axis=0)
         graph.make_node(
             'Reshape',
             inputs=[node.input('X')[0], final_shape],
@@ -1466,7 +1483,7 @@ class GaussianRandom():
 
 @op_mapper('uniform_random_batch_size_like')
 class UniformRandom():
-    support_opset_version_range = (1, 12)
+    support_opset_version_range = (7, 15)
 
     @classmethod
     def opset_1(cls, graph, node, **kw):

--- a/tests/test_auto_scan_flatten.py
+++ b/tests/test_auto_scan_flatten.py
@@ -50,14 +50,22 @@ class TestFlattenConvert(OPConvertAutoScanTest):
 
         dtype = draw(st.sampled_from(["int32", "int64", "float32", "float64"]))
 
+        # 生成合法的start_axis
         start_axis = draw(
             st.integers(
-                min_value=-len(input_shape), max_value=len(input_shape) - 1))
+                min_value=0, max_value=len(input_shape) - 1))
 
-        if start_axis == len(input_shape) - 1 or start_axis == -1:
-            stop_axis = -1
-        else:
-            stop_axis = start_axis + 1
+        # 生成合法的stop_axis
+        stop_axis = draw(
+            st.integers(
+                min_value=start_axis, max_value=len(input_shape) - 1))
+
+        # 随机将start_axis转为负数
+        if draw(st.booleans()):
+            start_axis -= len(input_shape)
+        # 随机将stop_axis转为负数
+        if draw(st.booleans()):
+            stop_axis -= len(input_shape)
 
         config = {
             "op_names": ["flatten_contiguous_range"],

--- a/tests/test_auto_scan_flatten.py
+++ b/tests/test_auto_scan_flatten.py
@@ -52,12 +52,12 @@ class TestFlattenConvert(OPConvertAutoScanTest):
 
         start_axis = draw(
             st.integers(
-                min_value=0, max_value=len(input_shape) // 2))
+                min_value=-len(input_shape), max_value=len(input_shape) - 1))
 
-        stop_axis = draw(
-            st.integers(
-                min_value=len(input_shape) // 2, max_value=len(input_shape) -
-                1))
+        if start_axis == len(input_shape) - 1 or start_axis == -1:
+            stop_axis = -1
+        else:
+            stop_axis = start_axis + 1
 
         config = {
             "op_names": ["flatten_contiguous_range"],


### PR DESCRIPTION
### Do follow contributes
1、增加flatten的start_axis以及stop_axis为负数单测
2、修复flatten_contiguous_range实现逻辑，分为四种情况：
- start_axis==0 && end_axis==dims-1，直接reshape(-1)
- start_axis==0 && end_axis<dims-1，reshape(-1,slice_end)，slice一次
- start_axis>0 && end_axis==dims-1, reshape(slice_start,-1)，slice一次
- start_aixs>0 && end_aixs < dims-1, reshape(slice_start,-1,slice_end)，slice两次
