### PR TITLE
Add multiclass_nms3 operator

### DIFF
--- a/p2o_exec.cpp
+++ b/p2o_exec.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
     parser.Init(argv[1], argv[2]);
   }
   paddle2onnx::ModelExporter me;
-  auto onnx_proto = me.Run(parser, 7, true, true, false, true);
+  auto onnx_proto = me.Run(parser, 10, false, true, true, true);
   std::fstream out("model.onnx", std::ios::out | std::ios::binary);
   out << onnx_proto;
   out.close();

--- a/p2o_exec.cpp
+++ b/p2o_exec.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
     parser.Init(argv[1], argv[2]);
   }
   paddle2onnx::ModelExporter me;
-  auto onnx_proto = me.Run(parser, 7, true, true);
+  auto onnx_proto = me.Run(parser, 7, true, true, false, true);
   std::fstream out("model.onnx", std::ios::out | std::ios::binary);
   out << onnx_proto;
   out.close();

--- a/paddle2onnx/mapper/detection/multiclass_nms.cc
+++ b/paddle2onnx/mapper/detection/multiclass_nms.cc
@@ -236,14 +236,13 @@ void NMSMapper::Opset10(OnnxHelper* helper) {
   } else {
     auto value_1 =
         helper->Constant({1}, GetOnnxDtype(boxes_info[0].dtype), float(1.0));
-    auto split_boxes = helper->MakeNode("Split", {boxes_info[0].name}, 4);
-    AddAttribute(split_boxes, "axis", int64_t(2));
-    AddAttribute(split_boxes, "split", std::vector<int64_t>(4, 1));
-    auto xmax = helper->MakeNode("Add", {split_boxes->output(2), value_1});
-    auto ymax = helper->MakeNode("Add", {split_boxes->output(3), value_1});
+    auto split_boxes = helper->Split(boxes_info[0].name,
+                                     std::vector<int64_t>(4, 1), int64_t(2));
+    auto xmax = helper->MakeNode("Add", {split_boxes[2], value_1});
+    auto ymax = helper->MakeNode("Add", {split_boxes[3], value_1});
     auto new_boxes = helper->MakeNode(
-        "Concat", {split_boxes->output(0), split_boxes->output(1),
-                   xmax->output(0), ymax->output(0)});
+        "Concat",
+        {split_boxes[0], split_boxes[1], xmax->output(0), ymax->output(0)});
     AddAttribute(new_boxes, "axis", int64_t(2));
     helper->MakeNode("NonMaxSuppression",
                      {new_boxes->output(0), score_info[0].name, nms_top_k,

--- a/paddle2onnx/mapper/detection/multiclass_nms.cc
+++ b/paddle2onnx/mapper/detection/multiclass_nms.cc
@@ -1,0 +1,255 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle2onnx/mapper/detection/multiclass_nms.h"
+
+namespace paddle2onnx {
+
+REGISTER_MAPPER(multiclass_nms3, NMSMapper);
+
+int32_t NMSMapper::GetMinOpset(bool verbose) {
+  std::vector<TensorInfo> boxes_info =
+      parser_->GetOpInput(block_idx_, op_idx_, "BBoxes");
+  std::vector<TensorInfo> score_info =
+      parser_->GetOpInput(block_idx_, op_idx_, "Scores");
+  if (score_info[0].Rank() != 3) {
+    if (verbose) {
+      std::cerr << "Paddle2ONNX: Lod Tensor input is not supported in "
+                   "multiclass_nms3 operator, which means the shape of "
+                   "input(scores) is [M, C] now, but it desire [N, C, M]."
+                << std::endl;
+    }
+    return -1;
+  }
+  if (boxes_info[0].Rank() != 3) {
+    if (verbose) {
+      std::cerr << "Paddle2ONNX: Only support input boxes as 3-D Tensor in  "
+                   "multiclass_nms3 operator, but now it's rank is "
+                << boxes_info[0].Rank() << "." << std::endl;
+    }
+    return -1;
+  }
+  if (boxes_info[0].shape[1] < 0 || boxes_info[0].shape[2] < 0) {
+    if (verbose) {
+      std::cerr << "Paddle2ONNX: The 2nd and 3rd dimension of input bboxes "
+                   "tensor of multiclass_nms should be fixed, but now the "
+                   "shape is ["
+                << boxes_info[0].shape[0] << ", " << boxes_info[0].shape[1]
+                << ", " << boxes_info[0].shape[2] << "]." << std::endl;
+    }
+    return -1;
+  }
+  if (score_info[0].shape[1] < 0 || score_info[0].shape[2] < 0) {
+    if (verbose) {
+      std::cerr << "Paddle2ONNX: The 2nd and 3rd dimension of input scores "
+                   "tensor of multiclass_nms should be fixed, but now the "
+                   "shape is ["
+                << score_info[0].shape[0] << ", " << score_info[0].shape[1]
+                << ", " << score_info[0].shape[2] << "]." << std::endl;
+    }
+    return -1;
+  }
+  return 10;
+}
+
+void NMSMapper::KeepTopK(OnnxHelper* helper,
+                         const std::string& selected_indices) {
+  auto boxes_info = parser_->GetOpInput(block_idx_, op_idx_, "BBoxes");
+  auto score_info = parser_->GetOpInput(block_idx_, op_idx_, "Scores");
+  auto out_info = parser_->GetOpOutput(block_idx_, op_idx_, "Out");
+  auto index_info = parser_->GetOpOutput(block_idx_, op_idx_, "Index");
+  auto num_rois_info = parser_->GetOpOutput(block_idx_, op_idx_, "NmsRoisNum");
+  auto value_0 =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, int64_t(0));
+  auto value_1 =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, int64_t(1));
+  auto value_2 =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, int64_t(2));
+  auto value_neg_1 =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, int64_t(-1));
+
+  auto class_id = helper->MakeNode("Gather", {selected_indices, value_1});
+  AddAttribute(class_id, "axis", int64_t(1));
+
+  auto box_id = helper->MakeNode("Gather", {selected_indices, value_2});
+  AddAttribute(box_id, "axis", int64_t(1));
+
+  auto filtered_class_id = class_id->output(0);
+  auto filtered_box_id = box_id->output(0);
+  if (background_label_ >= 0) {
+    auto filter_indices = MapperHelper::Get()->GenName("nms.filter_background");
+    auto squeezed_class_id =
+        helper->Squeeze(class_id->output(0), std::vector<int64_t>(1, 1));
+    if (background_label_ > 0) {
+      auto background = helper->Constant(
+          {1}, ONNX_NAMESPACE::TensorProto::INT64, background_label_);
+      auto diff = helper->MakeNode("Sub", {squeezed_class_id, background});
+      helper->MakeNode("NonZero", {diff->output(0)}, {filter_indices});
+    } else if (background_label_ == 0) {
+      helper->MakeNode("NonZero", {squeezed_class_id}, {filter_indices});
+    }
+    auto new_class_id =
+        helper->MakeNode("Gather", {filtered_class_id, filter_indices});
+    AddAttribute(new_class_id, "axis", int64_t(0));
+    auto new_box_id =
+        helper->MakeNode("Gather", {box_id->output(0), filter_indices});
+    AddAttribute(new_box_id, "axis", int64_t(0));
+    filtered_class_id = new_class_id->output(0);
+    filtered_box_id = new_box_id->output(0);
+  }
+
+  // Here is a little complicated
+  // Since we need to gather all the scores for the final boxes to filter the
+  // top-k boxes Now we have the follow inputs
+  //    - scores: [N, C, M] N means batch size(but now it will be regarded as
+  //    1); C means number of classes; M means number of boxes for each classes
+  //    - selected_indices: [num_selected_indices, 3], and 3 means [batch,
+  //    class_id, box_id]. We will use this inputs to gather score
+  // So now we will first flatten `scores` to shape of [1 * C * M], then we
+  // gather scores by each elements in `selected_indices` The index need be
+  // calculated as
+  //    `gather_index = class_id * M + box_id`
+  auto flatten_score = helper->Flatten(score_info[0].name);
+  auto num_boxes_each_class = helper->Constant(
+      {1}, ONNX_NAMESPACE::TensorProto::INT64, score_info[0].shape[2]);
+  auto gather_indices_0 =
+      helper->MakeNode("Mul", {filtered_class_id, num_boxes_each_class});
+  auto gather_indices_1 =
+      helper->MakeNode("Add", {gather_indices_0->output(0), filtered_box_id});
+  auto gather_indices = helper->Flatten(gather_indices_1->output(0));
+  auto gathered_scores =
+      helper->MakeNode("Gather", {flatten_score, gather_indices});
+  AddAttribute(gathered_scores, "axis", int64_t(0));
+
+  // Now we will perform keep_top_k process
+  // First we need to check if the number of remaining boxes is greater than
+  // keep_top_k Otherwise, we will downgrade the keep_top_k to number of
+  // remaining boxes
+  auto final_classes = filtered_class_id;
+  auto final_boxes_id = filtered_box_id;
+  auto final_scores = gathered_scores->output(0);
+  if (keep_top_k_ > 0) {
+    // get proper topk
+    auto shape_of_scores = helper->MakeNode("Shape", {final_scores});
+    auto num_of_boxes =
+        helper->Slice(shape_of_scores->output(0), std::vector<int64_t>(1, 0),
+                      std::vector<int64_t>(1, 0), std::vector<int64_t>(1, 1));
+    auto top_k =
+        helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, keep_top_k_);
+    auto ensemble_value = helper->MakeNode("Concat", {num_of_boxes, top_k});
+    AddAttribute(ensemble_value, "axis", int64_t(0));
+    auto new_top_k = helper->MakeNode("ReduceMin", {ensemble_value->output(0)});
+    AddAttribute(new_top_k, "axes", std::vector<int64_t>(1, 0));
+    AddAttribute(new_top_k, "keepdims", int64_t(1));
+
+    // the output is topk_scores, topk_score_indices
+    auto topk_node =
+        helper->MakeNode("TopK", {final_scores, new_top_k->output(0)}, 2);
+    auto topk_scores =
+        helper->MakeNode("Gather", {final_scores, topk_node->output(1)});
+    AddAttribute(topk_scores, "axis", int64_t(0));
+    auto topk_classes =
+        helper->MakeNode("Gather", {filtered_class_id, topk_node->output(1)});
+    AddAttribute(topk_classes, "axis", int64_t(1));
+    auto topk_boxes_id =
+        helper->MakeNode("Gather", {filtered_box_id, topk_node->output(1)});
+    AddAttribute(topk_boxes_id, "axis", int64_t(1));
+
+    final_boxes_id = topk_boxes_id->output(0);
+    final_scores = topk_scores->output(0);
+    final_classes = topk_classes->output(0);
+  }
+
+  auto flatten_boxes_id = helper->Flatten({final_boxes_id});
+  auto gathered_selected_boxes =
+      helper->MakeNode("Gather", {boxes_info[0].name, flatten_boxes_id});
+  AddAttribute(gathered_selected_boxes, "axis", int64_t(1));
+
+  auto float_classes = helper->MakeNode("Cast", {final_classes});
+  AddAttribute(float_classes, "to", ONNX_NAMESPACE::TensorProto::FLOAT);
+
+  std::vector<int64_t> shape{1, -1, 1};
+  auto unsqueezed_scores = helper->Reshape({final_scores}, shape);
+
+  auto box_result =
+      helper->MakeNode("Concat", {float_classes->output(0), unsqueezed_scores,
+                                  gathered_selected_boxes->output(0)});
+  AddAttribute(box_result, "axis", int64_t(2));
+  helper->Squeeze({box_result->output(0)}, {out_info[0].name},
+                  std::vector<int64_t>(1, 0));
+
+  // other outputs, we don't use sometimes
+  // there's lots of Cast in exporting
+  // TODO(jiangjiajun) A pass to eleminate all the useless Cast is needed
+  auto reshaped_index_result =
+      helper->Reshape({flatten_boxes_id}, {int64_t(-1), int64_t(1)});
+  auto index_result =
+      helper->MakeNode("Cast", {reshaped_index_result}, {index_info[0].name});
+  AddAttribute(index_result, "to", GetOnnxDtype(index_info[0].dtype));
+
+  auto out_box_shape = helper->MakeNode("Shape", {box_result->output(0)});
+  auto num_rois_result =
+      helper->Slice({out_box_shape->output(0)}, std::vector<int64_t>(1, 0),
+                    std::vector<int64_t>(1, 0), std::vector<int64_t>(1, 1));
+  auto int32_num_rois_result =
+      helper->MakeNode("Cast", {num_rois_result}, {num_rois_info[0].name});
+  AddAttribute(int32_num_rois_result, "to",
+               GetOnnxDtype(num_rois_info[0].dtype));
+}
+
+void NMSMapper::Opset10(OnnxHelper* helper) {
+  std::vector<TensorInfo> boxes_info =
+      parser_->GetOpInput(block_idx_, op_idx_, "BBoxes");
+  std::vector<TensorInfo> score_info =
+      parser_->GetOpInput(block_idx_, op_idx_, "Scores");
+  if (boxes_info[0].shape[0] != 1) {
+    std::cerr << "[WARN] Due to the operator multiclass_nms, the exported ONNX "
+                 "model will only supports inference with input batch_size == "
+                 "1."
+              << std::endl;
+  }
+  int64_t num_classes = score_info[0].shape[1];
+  auto score_threshold = helper->Constant(
+      {1}, ONNX_NAMESPACE::TensorProto::FLOAT, score_threshold_);
+  auto nms_threshold =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::FLOAT, nms_threshold_);
+  auto nms_top_k =
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, nms_top_k_);
+
+  auto selected_box_index = MapperHelper::Get()->GenName("nms.selected_index");
+  if (normalized_) {
+    helper->MakeNode("NonMaxSuppression",
+                     {boxes_info[0].name, score_info[0].name, nms_top_k,
+                      nms_threshold, score_threshold},
+                     {selected_box_index});
+  } else {
+    auto value_1 =
+        helper->Constant({1}, GetOnnxDtype(boxes_info[0].dtype), float(1.0));
+    auto split_boxes = helper->MakeNode("Split", {boxes_info[0].name}, 4);
+    AddAttribute(split_boxes, "axis", int64_t(2));
+    AddAttribute(split_boxes, "split", std::vector<int64_t>(4, 1));
+    auto xmax = helper->MakeNode("Add", {split_boxes->output(2), value_1});
+    auto ymax = helper->MakeNode("Add", {split_boxes->output(3), value_1});
+    auto new_boxes = helper->MakeNode(
+        "Concat", {split_boxes->output(0), split_boxes->output(1),
+                   xmax->output(0), ymax->output(0)});
+    AddAttribute(new_boxes, "axis", int64_t(2));
+    helper->MakeNode("NonMaxSuppression",
+                     {new_boxes->output(0), score_info[0].name, nms_top_k,
+                      nms_threshold, score_threshold},
+                     {selected_box_index});
+  }
+  KeepTopK(helper, selected_box_index);
+}
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/detection/multiclass_nms.h
+++ b/paddle2onnx/mapper/detection/multiclass_nms.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "paddle2onnx/mapper/mapper.h"
+
+namespace paddle2onnx {
+
+class NMSMapper : public Mapper {
+ public:
+  NMSMapper(const PaddleParser& p, int64_t block_id, int64_t op_id)
+      : Mapper(p, block_id, op_id) {
+    // NMS is a post process operators for object detection
+    // We have found there're difference between `multi_class_nms3` in
+    // PaddlePaddle and `NonMaxSuppresion` in ONNX
+    MarkAsExperimentalOp();
+    auto op = parser_->GetOpDesc(block_idx_, op_idx_);
+    parser_->GetOpAttr(op, "normalized", &normalized_);
+    parser_->GetOpAttr(op, "nms_threshold", &nms_threshold_);
+    parser_->GetOpAttr(op, "score_threshold", &score_threshold_);
+    parser_->GetOpAttr(op, "nms_eta", &nms_eta_);
+    // The `nms_top_k` in Paddle and `max_output_boxes_per_class` in ONNX share
+    // the same meaning But the filter process may not be same Since NMS is just
+    // a post process for Detection, we are not going to export it with exactly
+    // same result. We will make a precision performance in COCO or Pascal VOC
+    // data later.
+    parser_->GetOpAttr(op, "nms_top_k", &nms_top_k_);
+    parser_->GetOpAttr(op, "background_label", &background_label_);
+    parser_->GetOpAttr(op, "keep_top_k", &keep_top_k_);
+  }
+
+  int32_t GetMinOpset(bool verbose = false);
+  void KeepTopK(OnnxHelper* helper, const std::string& selected_indices);
+  void Opset10(OnnxHelper* helper);
+
+ private:
+  bool normalized_;
+  float nms_threshold_;
+  float score_threshold_;
+  float nms_eta_;
+  int64_t nms_top_k_;
+  int64_t background_label_;
+  int64_t keep_top_k_;
+};
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -43,11 +43,15 @@ struct ModelExporter {
   // If the model is not convertable, return -1
   int32_t GetMinOpset(const PaddleParser& parser, bool verbose = false);
 
-  bool CheckIfOpSupported(const PaddleParser& parser, std::set<std::string>*);
+  bool CheckIfOpSupported(const PaddleParser& parser,
+                          std::set<std::string>* unsupported_ops,
+                          bool enable_experimental_op);
 
  public:
   std::string Run(const PaddleParser& parser, int opset_version = 9,
-                  bool auto_upgrade_opset = true, bool verbose = false);
+                  bool auto_upgrade_opset = true, bool verbose = false,
+                  bool enable_onnx_checker = true,
+                  bool enable_experimental_op = false);
 };
 
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -28,6 +28,11 @@ class Mapper {
     op_idx_ = op_id;
   }
 
+  // Some operators is not implement very well, e.g the output may not be same
+  // We mark these operators as experimental, these operators requires double
+  // checking after model exported.
+  virtual void MarkAsExperimentalOp() { is_experimental_op_ = true; }
+  virtual bool IsExperimentalOp() const { return is_experimental_op_; }
   // the return value in [7, 15], represent the minimum opset_version
   // if return value < 0, means the op is not supported.
   virtual int32_t GetMinOpset(bool verbose = false) { return 7; }
@@ -80,6 +85,7 @@ class Mapper {
   }
 
   virtual ~Mapper() = default;
+  bool is_experimental_op_ = false;
   const PaddleParser* parser_;
   int32_t block_idx_;
   int32_t op_idx_;

--- a/paddle2onnx/mapper/nn/flatten.cc
+++ b/paddle2onnx/mapper/nn/flatten.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
 #include "paddle2onnx/mapper/nn/flatten.h"
 #include <vector>
 

--- a/paddle2onnx/mapper/nn/flatten.cc
+++ b/paddle2onnx/mapper/nn/flatten.cc
@@ -33,10 +33,9 @@ void FlattenMapper::Opset7(OnnxHelper* helper) {
       parser_->GetOpOutput(block_idx_, op_idx_, "Out");
 
   auto unknown_dim_node =
-      helper->MakeConstant({1}, ONNX_NAMESPACE::TensorProto::INT64, -1);
+      helper->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, -1);
   if (start_axis_ == 0 && stop_axis_ == input_info[0].Rank() - 1) {
-    helper->MakeNode("Reshape",
-                     {input_info[0].name, unknown_dim_node->output(0)},
+    helper->MakeNode("Reshape", {input_info[0].name, unknown_dim_node},
                      {output_info[0].name});
   } else {
     auto input_shape_node = helper->MakeNode("Shape", {input_info[0].name});
@@ -44,9 +43,8 @@ void FlattenMapper::Opset7(OnnxHelper* helper) {
       auto second_part_shape =
           helper->Slice(input_shape_node->output(0), {0}, {stop_axis_ + 1},
                         {input_info[0].Rank()});
-      auto new_shape_node = helper->MakeNode(
-          "Concat",
-          {unknown_dim_node->output(0), second_part_shape->output(0)});
+      auto new_shape_node =
+          helper->MakeNode("Concat", {unknown_dim_node, second_part_shape});
       AddAttribute(new_shape_node, "axis", int64_t(0));
       helper->MakeNode("Reshape",
                        {input_info[0].name, new_shape_node->output(0)},
@@ -54,8 +52,8 @@ void FlattenMapper::Opset7(OnnxHelper* helper) {
     } else if (stop_axis_ == input_info[0].Rank() - 1) {
       auto first_part_shape =
           helper->Slice(input_shape_node->output(0), {0}, {0}, {start_axis_});
-      auto new_shape_node = helper->MakeNode(
-          "Concat", {first_part_shape->output(0), unknown_dim_node->output(0)});
+      auto new_shape_node =
+          helper->MakeNode("Concat", {first_part_shape, unknown_dim_node});
       AddAttribute(new_shape_node, "axis", int64_t(0));
       helper->MakeNode("Reshape",
                        {input_info[0].name, new_shape_node->output(0)},
@@ -67,8 +65,7 @@ void FlattenMapper::Opset7(OnnxHelper* helper) {
           helper->Slice(input_shape_node->output(0), {0}, {stop_axis_ + 1},
                         {input_info[0].Rank()});
       auto new_shape_node = helper->MakeNode(
-          "Concat", {first_part_shape->output(0), unknown_dim_node->output(0),
-                     second_part_shape->output(0)});
+          "Concat", {first_part_shape, unknown_dim_node, second_part_shape});
       AddAttribute(new_shape_node, "axis", int64_t(0));
       helper->MakeNode("Reshape",
                        {input_info[0].name, new_shape_node->output(0)},

--- a/paddle2onnx/mapper/nn/scale.cc
+++ b/paddle2onnx/mapper/nn/scale.cc
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#pragma once
 #include "paddle2onnx/mapper/nn/scale.h"
 #include <vector>
 

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -127,6 +127,8 @@ std::shared_ptr<ONNX_NAMESPACE::NodeProto> OnnxHelper::MakeNode(
     const std::string& op_type, const std::vector<std::string>& inputs,
     const std::vector<std::string>& outputs) {
   auto node = std::make_shared<ONNX_NAMESPACE::NodeProto>();
+  auto node_name = MapperHelper::Get()->GenName(op_type);
+  node->set_name(node_name);
   node->set_op_type(op_type);
   for (size_t i = 0; i < inputs.size(); ++i) {
     node->add_input(inputs[i]);
@@ -142,6 +144,8 @@ std::shared_ptr<ONNX_NAMESPACE::NodeProto> OnnxHelper::MakeNode(
     const std::string& op_type, const std::vector<std::string>& inputs,
     int num_outputs) {
   auto node = std::make_shared<ONNX_NAMESPACE::NodeProto>();
+  auto node_name = MapperHelper::Get()->GenName(op_type);
+  node->set_name(node_name);
   node->set_op_type(op_type);
   for (size_t i = 0; i < inputs.size(); ++i) {
     node->add_input(inputs[i]);
@@ -301,8 +305,10 @@ std::string OnnxHelper::Slice(const std::string& input,
     auto axes_node = MakeConstant(ONNX_NAMESPACE::TensorProto::INT64, axes);
     auto starts_node = MakeConstant(ONNX_NAMESPACE::TensorProto::INT64, starts);
     auto ends_node = MakeConstant(ONNX_NAMESPACE::TensorProto::INT64, ends);
-    auto node = MakeNode("Slice", {input, starts_node->output(0),
-                                   ends_node->output(0), axes_node->output(0)});
+    auto node = MakeNode("Slice",
+                         {input, starts_node->output(0), ends_node->output(0),
+                          axes_node->output(0)},
+                         {output});
   }
   return output;
 }

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -321,4 +321,46 @@ std::string OnnxHelper::Slice(const std::string& input,
   return Slice(input, output, axes, starts, ends);
 }
 
+std::vector<std::string> OnnxHelper::Split(
+    const std::string& input, const std::vector<std::string>& outputs,
+    const std::vector<int64_t>& split, int64_t axis) {
+  Assert(outputs.size() > 0 || split.size() > 0,
+         "OnnxHelper::Split requires the size of outputs or the size of split "
+         "> 0.");
+  auto node = std::make_shared<ONNX_NAMESPACE::NodeProto>();
+  auto node_name = MapperHelper::Get()->GenName("Split");
+  node->set_name(node_name);
+  node->set_op_type("Split");
+  node->add_input(input);
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    node->add_output(outputs[i]);
+  }
+  AddAttribute(node, "axis", axis);
+  if (split.size() > 0) {
+    Assert(outputs.size() == split.size(),
+           "OnnxHelper::Split While size of outputs and the size of split both "
+           "> 0, their size must be same.");
+    if (opset_version < 13) {
+      AddAttribute(node, "split", split);
+    } else {
+      auto split_const = Constant(ONNX_NAMESPACE::TensorProto::INT64, split);
+      node->add_input(split_const);
+    }
+  }
+  nodes.push_back(node);
+  return outputs;
+}
+
+std::vector<std::string> OnnxHelper::Split(const std::string& input,
+                                           const std::vector<int64_t>& split,
+                                           int64_t axis) {
+  Assert(split.size() > 0,
+         "OnnxHelper::Split requires the size of parameter split > 0.");
+  std::vector<std::string> outputs(split.size());
+  for (size_t i = 0; i < split.size(); ++i) {
+    outputs[i] = MapperHelper::Get()->GenName("helper.split");
+  }
+  return Split(input, outputs, split, axis);
+}
+
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/onnx_helper.h
+++ b/paddle2onnx/mapper/onnx_helper.h
@@ -106,6 +106,13 @@ class OnnxHelper {
   std::string Slice(const std::string& input, const std::vector<int64_t>& axes,
                     const std::vector<int64_t>& starts,
                     const std::vector<int64_t>& ends);
+  std::vector<std::string> Split(const std::string& input,
+                                 const std::vector<std::string>& outputs,
+                                 const std::vector<int64_t>& split,
+                                 int64_t axis);
+  std::vector<std::string> Split(const std::string& input,
+                                 const std::vector<int64_t>& split,
+                                 int64_t axis);
 
   template <typename T>
   std::string Constant(const std::string& output,


### PR DESCRIPTION
- 新增算子`multiclass_nms3`
- 新增`experimental_op`机制
   - 定义OP时，调用`MarkAsExperimentalOp`标记OP，在使用`ModelExporter.Run`进行导时，只有传入`enable_experimental_op=true`，才会支持该OP
   - 此方式将在离线模型转换时启用，对于稳定性要求高的场景不会打开
- `MakeNode`时添加为Node自动命名，便于模型debug
- 修复helper函数`Slice`问题
- 增加helper函数`Split`