### PR TITLE
Modify auto scan test for all opset_version

### DIFF
--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -284,6 +284,11 @@ class APIOnnx(object):
         """
         self._mkdir()
         self.set_input_spec()
+
+        # test from min_opset_version to 15
+        min_opset_version = min(self._version)
+        self._version = list(range(min_opset_version), 16)
+
         for place in self.places:
             paddle.set_device(place)
 

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -287,7 +287,7 @@ class APIOnnx(object):
 
         # test from min_opset_version to 15
         min_opset_version = min(self._version)
-        self._version = list(range(min_opset_version), 16)
+        self._version = list(range(min_opset_version, 16))
 
         for place in self.places:
             paddle.set_device(place)


### PR DESCRIPTION
单测中改为从小最opset版本，测到15，覆盖原始未测的中间OPset