### PR TITLE
Add output name choose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you need to configure the input shape, use the following command:
 |--enable_paddle_fallback| **[Optional]**  Whether custom op is exported using paddle_fallback mode. Default value is False|
 |--input_shape_dict| **[Optional]**  Configure the input shape, the default is empty|
 |--version |**[Optional]** check the version of paddle2onnx |
-|--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "["my_output1","my_output2"]"，or in dict form，for example："{"paddle_output1":"my_output1", "paddle_output2":"my_output2"}"|
+|--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "['my_output1','my_output2']"，or in dict form，for example："{'paddle_output1':'my_output1', 'paddle_output2':'my_output2'}"|
 
 - Two types of PaddlePaddle models
    - Combined model, parameters saved in one binary file. --model_filename and --params_filename represents the file name and parameter name under the directory designated by --model_dir. --model_filename and --params_filename are valid only with parameter --model_dir.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you need to configure the input shape, use the following command:
 |--enable_paddle_fallback| **[Optional]**  Whether custom op is exported using paddle_fallback mode. Default value is False|
 |--input_shape_dict| **[Optional]**  Configure the input shape, the default is empty|
 |--version |**[Optional]** check the version of paddle2onnx |
+|--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "["my_output1","my_output2"]"，or in dict form，for example：--output_names "{"paddle_output":"my_output1"}"|
 
 - Two types of PaddlePaddle models
    - Combined model, parameters saved in one binary file. --model_filename and --params_filename represents the file name and parameter name under the directory designated by --model_dir. --model_filename and --params_filename are valid only with parameter --model_dir.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you need to configure the input shape, use the following command:
 |--enable_paddle_fallback| **[Optional]**  Whether custom op is exported using paddle_fallback mode. Default value is False|
 |--input_shape_dict| **[Optional]**  Configure the input shape, the default is empty|
 |--version |**[Optional]** check the version of paddle2onnx |
-|--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "["my_output1","my_output2"]"，or in dict form，for example：--output_names "{"paddle_output":"my_output1"}"|
+|--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "["my_output1","my_output2"]"，or in dict form，for example："{"paddle_output1":"my_output1", "paddle_output2":"my_output2"}"|
 
 - Two types of PaddlePaddle models
    - Combined model, parameters saved in one binary file. --model_filename and --params_filename represents the file name and parameter name under the directory designated by --model_dir. --model_filename and --params_filename are valid only with parameter --model_dir.

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,6 +63,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
 |--input_shape_dict| **[可选]**  配置输入的shape, 默认为空|
 |--version |**[可选]** 查看paddle2onnx版本 |
+|--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "["my_output1","my_output2"]"，或者dict形式，如：--output_names "{"paddle_output":"my_output1"}"|
 
 - PaddlePaddle模型的两种存储形式：
    - 参数被保存在一个单独的二进制文件中（combined），需要在指定--model_dir的前提下，指定--model_filename, --params_filename, 分别表示--model_dir目录下的网络文件名称和参数文件名称。

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,7 +63,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
 |--input_shape_dict| **[可选]**  配置输入的shape, 默认为空|
 |--version |**[可选]** 查看paddle2onnx版本 |
-|--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "["my_output1","my_output2"]"，或者dict形式，如：--output_names "{"paddle_output1":"my_output1", "paddle_output2":"my_output2"}"|
+|--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "['my_output1','my_output2']"，或者dict形式，如：--output_names "{'paddle_output1':'my_output1', 'paddle_output2':'my_output2'}"|
 
 - PaddlePaddle模型的两种存储形式：
    - 参数被保存在一个单独的二进制文件中（combined），需要在指定--model_dir的前提下，指定--model_filename, --params_filename, 分别表示--model_dir目录下的网络文件名称和参数文件名称。

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,7 +63,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
 |--input_shape_dict| **[可选]**  配置输入的shape, 默认为空|
 |--version |**[可选]** 查看paddle2onnx版本 |
-|--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "["my_output1","my_output2"]"，或者dict形式，如：--output_names "{"paddle_output":"my_output1"}"|
+|--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "["my_output1","my_output2"]"，或者dict形式，如：--output_names "{"paddle_output1":"my_output1", "paddle_output2":"my_output2"}"|
 
 - PaddlePaddle模型的两种存储形式：
    - 参数被保存在一个单独的二进制文件中（combined），需要在指定--model_dir的前提下，指定--model_filename, --params_filename, 分别表示--model_dir目录下的网络文件名称和参数文件名称。

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -203,11 +203,11 @@ def main():
         operator_export_type = "PaddleFallback"
 
     if args.output_names is not None:
-        print("output names is not none")
         if not isinstance(args.output_names, (list, dict)):
             raise TypeError(
                 "The output_names should be 'list' or 'dict', but received type is %s."
                 % type(args.output_names))
+
     program2onnx(
         args.model_dir,
         args.save_file,

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -81,6 +81,13 @@ def arg_parser():
         action="store_true",
         default=False,
         help="get version of paddle2onnx")
+    parser.add_argument(
+       "--output_names",
+       "-on",
+       type=_text_type,
+       default="None",
+       help="define output names, e.g --output_names=[\"output1\"] or" \
+       "--output_names=[\"output1\", \"output2\", \"output3\"]")
     return parser
 
 
@@ -91,7 +98,8 @@ def program2onnx(model_dir,
                  opset_version=9,
                  enable_onnx_checker=False,
                  operator_export_type="ONNX",
-                 input_shape_dict=None):
+                 input_shape_dict=None,
+                 output_names=None):
     try:
         import paddle
     except:
@@ -156,7 +164,8 @@ def program2onnx(model_dir,
         target_vars=fetch_vars,
         opset_version=opset_version,
         enable_onnx_checker=enable_onnx_checker,
-        operator_export_type=operator_export_type)
+        operator_export_type=operator_export_type,
+        output_names=output_names)
 
 
 def main():
@@ -192,7 +201,8 @@ def main():
         opset_version=args.opset_version,
         enable_onnx_checker=args.enable_onnx_checker,
         operator_export_type=operator_export_type,
-        input_shape_dict=input_shape_dict)
+        input_shape_dict=input_shape_dict,
+        output_names=args.output_names)
 
 
 if __name__ == "__main__":

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -25,19 +25,9 @@ from paddle2onnx.utils import logging
 def str2list(v):
     if len(v) == 0:
         return None
-    print("orgin: ", v)
     v = v.replace(" ", "")
-    if v.count("["):
-        v = v[1:-1]
-        return [item for item in v.split(",")]
-    if v.count("{"):
-        v = v[1:-1]
-        print("v: ", v)
-        res_dict = {}
-        for item in v.split(","):
-            print(item)
-            res_dict[item.split(":")[0]] = item.split(":")[1]
-        return res_dict
+    v = eval(v)
+    return v
 
 
 def arg_parser():

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -36,7 +36,6 @@ def export_onnx(paddle_graph,
                                  operator_export_type, verbose,
                                  auto_update_opset)
     onnx_graph = PassManager.run_pass(onnx_graph, ['inplace_node_pass'])
-
     onnx_proto = onnx_graph.export_proto(enable_onnx_checker, output_names)
 
     if save_file is None:
@@ -59,7 +58,6 @@ def program2onnx(program,
                  enable_onnx_checker=False,
                  operator_export_type="ONNX",
                  auto_update_opset=True,
-                 output_names=None,
                  **configs):
     from paddle import fluid
     if hasattr(paddle, 'enable_static'):
@@ -85,9 +83,22 @@ def program2onnx(program,
 
         paddle_graph = PaddleGraph.build_from_program(program, feed_var_names,
                                                       target_vars, scope)
-        return export_onnx(paddle_graph, save_file, opset_version,
-                           enable_onnx_checker, operator_export_type,
-                           auto_update_opset, output_names)
+        output_names = None
+        if 'output_names' in configs:
+            output_names = configs['output_names']
+            if output_names is not None and not isinstance(output_names,
+                                                           (list, dict)):
+                raise TypeError(
+                    "The output_names should be 'list' or dict, but received type is %s."
+                    % type(output_names))
+        return export_onnx(
+            paddle_graph,
+            save_file,
+            opset_version,
+            enable_onnx_checker,
+            operator_export_type,
+            auto_update_opset,
+            output_names=output_names)
     else:
         raise TypeError(
             "the input 'program' should be 'Program', but received type is %s."
@@ -184,10 +195,10 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
     output_names = None
     if 'output_names' in configs:
         output_names = configs['output_names']
-        if not isinstance(output_names, list):
+        if not isinstance(output_names, (list, dict)):
             raise TypeError(
-                "The output_names should be 'list', but received type is %s." %
-                type(output_names))
+                "The output_names should be 'list' or dict, but received type is %s."
+                % type(output_names))
 
     return export_onnx(paddle_graph, save_file, opset_version,
                        enable_onnx_checker, operator_export_type, verbose,

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -30,13 +30,14 @@ def export_onnx(paddle_graph,
                 enable_onnx_checker=False,
                 operator_export_type="ONNX",
                 verbose=False,
-                auto_update_opset=True):
+                auto_update_opset=True,
+                output_names=None):
     onnx_graph = ONNXGraph.build(paddle_graph, opset_version,
                                  operator_export_type, verbose,
                                  auto_update_opset)
     onnx_graph = PassManager.run_pass(onnx_graph, ['inplace_node_pass'])
 
-    onnx_proto = onnx_graph.export_proto(enable_onnx_checker)
+    onnx_proto = onnx_graph.export_proto(enable_onnx_checker, output_names)
 
     if save_file is None:
         return onnx_proto
@@ -58,6 +59,7 @@ def program2onnx(program,
                  enable_onnx_checker=False,
                  operator_export_type="ONNX",
                  auto_update_opset=True,
+                 output_names=None,
                  **configs):
     from paddle import fluid
     if hasattr(paddle, 'enable_static'):
@@ -85,7 +87,7 @@ def program2onnx(program,
                                                       target_vars, scope)
         return export_onnx(paddle_graph, save_file, opset_version,
                            enable_onnx_checker, operator_export_type,
-                           auto_update_opset)
+                           auto_update_opset, output_names)
     else:
         raise TypeError(
             "the input 'program' should be 'Program', but received type is %s."
@@ -179,6 +181,14 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
                 "The auto_update_opset should be 'bool', but received type is %s."
                 % type(configs['auto_update_opset']))
 
+    output_names = None
+    if 'output_names' in configs:
+        output_names = configs['output_names']
+        if not isinstance(output_names, list):
+            raise TypeError(
+                "The output_names should be 'list', but received type is %s." %
+                type(output_names))
+
     return export_onnx(paddle_graph, save_file, opset_version,
                        enable_onnx_checker, operator_export_type, verbose,
-                       auto_update_opset)
+                       auto_update_opset, output_names)

--- a/paddle2onnx/graph/onnx_graph.py
+++ b/paddle2onnx/graph/onnx_graph.py
@@ -230,6 +230,8 @@ class ONNXGraph(Graph):
         return -1
 
     def change_output_names(self, onnx_proto, output_names):
+        logging.info("The output of the ONNX model is set to: {}".format(
+            output_names))
         if isinstance(output_names, list):
             assert len(output_names) == len(
                 onnx_proto.graph.output

--- a/paddle2onnx/graph/onnx_graph.py
+++ b/paddle2onnx/graph/onnx_graph.py
@@ -229,6 +229,45 @@ class ONNXGraph(Graph):
                 return i
         return -1
 
+    def change_output_names(self, onnx_proto, output_names):
+        if isinstance(output_names, list):
+            assert len(output_names) == len(
+                onnx_proto.graph.output
+            ), "The provided output names are inconsistent with the output number of the onnx model when output_names is list"
+            origin_output_names = []
+            for i in range(len(onnx_proto.graph.output)):
+                origin_output_names.append(onnx_proto.graph.output[i].name)
+                onnx_proto.graph.output[i].name = output_names[i]
+
+            for i in range(len(onnx_proto.graph.node)):
+                node = onnx_proto.graph.node[i]
+                for j in range(len(origin_output_names)):
+                    if origin_output_names[j] in node.output:
+                        index = self.find_index(node.output,
+                                                origin_output_names[j])
+                        onnx_proto.graph.node[i].output[index] = output_names[j]
+                    if origin_output_names[j] in node.input:
+                        index = self.find_index(node.input,
+                                                origin_output_names[j])
+                        onnx_proto.graph.node[i].input[index] = output_names[j]
+        if isinstance(output_names, dict):
+            for i in range(len(onnx_proto.graph.output)):
+                for key, value in output_names.items():
+                    if onnx_proto.graph.output[i].name == key:
+                        onnx_proto.graph.output[i].name = value
+
+            for i in range(len(onnx_proto.graph.node)):
+                node = onnx_proto.graph.node[i]
+                for key, value in output_names.items():
+                    if key in node.output:
+                        index = self.find_index(node.output, key)
+                        onnx_proto.graph.node[i].output[index] = value
+                    if key in node.input:
+                        index = self.find_index(node.input, key)
+                        onnx_proto.graph.node[i].input[index] = value
+
+        return onnx_proto
+
     def export_proto(self, enable_onnx_checker=False, output_names=None):
 
         op_nodes = [node.onnx_node for node in self.node_map.values()]
@@ -246,27 +285,8 @@ class ONNXGraph(Graph):
             opset_imports.append(helper.make_opsetid(custom_domain, 1))
         onnx_proto = helper.make_model(
             onnx_graph, producer_name=PRODUCER, opset_imports=opset_imports)
-
         if output_names is not None:
-            assert len(output_names) == len(
-                onnx_proto.graph.output
-            ), "The provided output names are inconsistent with the output number of the onnx model"
-            origin_output_names = []
-            for i in range(len(onnx_proto.graph.output)):
-                origin_output_names.append(onnx_proto.graph.output[i].name)
-                onnx_proto.graph.output[i].name = output_names[i]
-
-            for i in range(len(onnx_proto.graph.node)):
-                node = onnx_proto.graph.node[i]
-                for j in range(len(origin_output_names)):
-                    if origin_output_names[j] in node.output:
-                        index = self.find_index(node.output,
-                                                origin_output_names[j])
-                        onnx_proto.graph.node[i].output[index] = output_names[j]
-                    if origin_output_names[j] in node.input:
-                        index = self.find_index(node.input,
-                                                origin_output_names[j])
-                        onnx_proto.graph.node[i].input[index] = output_names[j]
+            onnx_proto = self.change_output_names(onnx_proto, output_names)
 
         if enable_onnx_checker:
             check_model(onnx_proto)

--- a/paddle2onnx/graph/onnx_graph.py
+++ b/paddle2onnx/graph/onnx_graph.py
@@ -243,29 +243,48 @@ class ONNXGraph(Graph):
 
             for i in range(len(onnx_proto.graph.node)):
                 node = onnx_proto.graph.node[i]
+                # Prevent changed names from being changed again
+                output_visited_node = []
+                input_visited_node = []
                 for j in range(len(origin_output_names)):
                     if origin_output_names[j] in node.output:
                         index = self.find_index(node.output,
                                                 origin_output_names[j])
+                        if index in output_visited_node:
+                            continue
+                        output_visited_node.append(index)
                         onnx_proto.graph.node[i].output[index] = output_names[j]
                     if origin_output_names[j] in node.input:
                         index = self.find_index(node.input,
                                                 origin_output_names[j])
+                        if index in input_visited_node:
+                            continue
+                        input_visited_node.append(index)
                         onnx_proto.graph.node[i].input[index] = output_names[j]
         if isinstance(output_names, dict):
             for i in range(len(onnx_proto.graph.output)):
                 for key, value in output_names.items():
                     if onnx_proto.graph.output[i].name == key:
                         onnx_proto.graph.output[i].name = value
+                        break
 
             for i in range(len(onnx_proto.graph.node)):
                 node = onnx_proto.graph.node[i]
+                # Prevent changed names from being changed again
+                output_visited_node = []
+                input_visited_node = []
                 for key, value in output_names.items():
                     if key in node.output:
                         index = self.find_index(node.output, key)
+                        if index in output_visited_node:
+                            continue
+                        output_visited_node.append(index)
                         onnx_proto.graph.node[i].output[index] = value
                     if key in node.input:
                         index = self.find_index(node.input, key)
+                        if index in input_visited_node:
+                            continue
+                        input_visited_node.append(index)
                         onnx_proto.graph.node[i].input[index] = value
 
         return onnx_proto

--- a/paddle2onnx/graph/onnx_graph.py
+++ b/paddle2onnx/graph/onnx_graph.py
@@ -223,7 +223,14 @@ class ONNXGraph(Graph):
         vi = self.make_value_info(name, shape, dtype)
         self.output_nodes.append(vi)
 
-    def export_proto(self, enable_onnx_checker=False):
+    def find_index(self, node_inout, name):
+        for i in range(len(node_inout)):
+            if node_inout[i] == name:
+                return i
+        return -1
+
+    def export_proto(self, enable_onnx_checker=False, output_names=None):
+
         op_nodes = [node.onnx_node for node in self.node_map.values()]
         weight_nodes = [node for node in self.parameters.values()]
 
@@ -239,6 +246,27 @@ class ONNXGraph(Graph):
             opset_imports.append(helper.make_opsetid(custom_domain, 1))
         onnx_proto = helper.make_model(
             onnx_graph, producer_name=PRODUCER, opset_imports=opset_imports)
+
+        if output_names is not None:
+            assert len(output_names) == len(
+                onnx_proto.graph.output
+            ), "The provided output names are inconsistent with the output number of the onnx model"
+            origin_output_names = []
+            for i in range(len(onnx_proto.graph.output)):
+                origin_output_names.append(onnx_proto.graph.output[i].name)
+                onnx_proto.graph.output[i].name = output_names[i]
+
+            for i in range(len(onnx_proto.graph.node)):
+                node = onnx_proto.graph.node[i]
+                for j in range(len(origin_output_names)):
+                    if origin_output_names[j] in node.output:
+                        index = self.find_index(node.output,
+                                                origin_output_names[j])
+                        onnx_proto.graph.node[i].output[index] = output_names[j]
+                    if origin_output_names[j] in node.input:
+                        index = self.find_index(node.input,
+                                                origin_output_names[j])
+                        onnx_proto.graph.node[i].input[index] = output_names[j]
 
         if enable_onnx_checker:
             check_model(onnx_proto)


### PR DESCRIPTION
1. Add output name choose support.

#### 1. List type
```
paddle2onnx --model_dir ./  --model_filename model.pdmodel  --save_file model.onnx --opset_version 13 --enable_onnx_checker True --output_names "['my_output1','my_output2']"
```
#### 2. Dict type
```
# only change one output:
paddle2onnx --model_dir ./  --model_filename model.pdmodel  --save_file model.onnx --opset_version 13 --enable_onnx_checker True --output_names "{'paddle_output':'my_output1'}"

# change several outputs:
paddle2onnx --model_dir ./  --model_filename model.pdmodel  --save_file model.onnx --opset_version 13 --enable_onnx_checker True --output_names "{'paddle_output1':'my_output1', 'paddle_output2':'my_output2'}"
```