### PR TITLE
add enable_auto_update_opset choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you need to configure the input shape, use the following command:
 |--opset_version | **[Optional]** To configure the ONNX Opset version. Opset 9-11 are stably supported. Default value is 9.|
 |--enable_onnx_checker| **[Optional]**  To check the validity of the exported ONNX model. It is suggested to turn on the switch. If set to True, onnx>=1.7.0 is required. Default value is False|
 |--enable_paddle_fallback| **[Optional]**  Whether custom op is exported using paddle_fallback mode. Default value is False|
+|--enable_auto_update_opset| **[Optional]**  Whether enable auto_update_opset. Default value is True|
 |--input_shape_dict| **[Optional]**  Configure the input shape, the default is empty|
 |--version |**[Optional]** check the version of paddle2onnx |
 |--output_names| **[Optional]**  Set the output name of the model, the default is empty, support configuration in list form，for example：--output_names "['my_output1','my_output2']"，or in dict form，for example："{'paddle_output1':'my_output1', 'paddle_output2':'my_output2'}"|

--- a/README_zh.md
+++ b/README_zh.md
@@ -61,6 +61,7 @@ Paddle模型的参数保存在一个单独的二进制文件中（combined）:
 |--opset_version | **[可选]** 配置转换为ONNX的OpSet版本，目前比较稳定地支持9、10、11三个版本，默认为9 |
 |--enable_onnx_checker| **[可选]**  配置是否检查导出为ONNX模型的正确性, 建议打开此开关。若指定为True，需要安装 onnx>=1.7.0, 默认为False|
 |--enable_paddle_fallback| **[可选]**  配置custom op是否使用paddle_fallback模式导出, 默认为False|
+|--enable_auto_update_opset| **[可选]**  配置是否开启opset version自动校正功能, 默认为True|
 |--input_shape_dict| **[可选]**  配置输入的shape, 默认为空|
 |--version |**[可选]** 查看paddle2onnx版本 |
 |--output_names| **[可选]**  配置模型的输出名, 默认为空，支持配置为list形式，如：--output_names "['my_output1','my_output2']"，或者dict形式，如：--output_names "{'paddle_output1':'my_output1', 'paddle_output2':'my_output2'}"|

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -97,6 +97,11 @@ def arg_parser():
         help="define output names, e.g --output_names=\"[\"output1\"]\" or \
        --output_names=\"[\"output1\", \"output2\", \"output3\"]\" or \
        --output_names=\"{\"Paddleoutput\":\"Onnxoutput\"}\"")
+    parser.add_argument(
+        "--enable_auto_update_opset",
+        type=ast.literal_eval,
+        default=True,
+        help="whether enable auto_update_opset, default is True")
     return parser
 
 
@@ -108,7 +113,8 @@ def program2onnx(model_dir,
                  enable_onnx_checker=False,
                  operator_export_type="ONNX",
                  input_shape_dict=None,
-                 output_names=None):
+                 output_names=None,
+                 auto_update_opset=True):
     try:
         import paddle
     except:
@@ -173,6 +179,7 @@ def program2onnx(model_dir,
         opset_version=opset_version,
         enable_onnx_checker=enable_onnx_checker,
         operator_export_type=operator_export_type,
+        auto_update_opset=auto_update_opset,
         output_names=output_names)
 
 
@@ -217,7 +224,8 @@ def main():
         enable_onnx_checker=args.enable_onnx_checker,
         operator_export_type=operator_export_type,
         input_shape_dict=input_shape_dict,
-        output_names=args.output_names)
+        output_names=args.output_names,
+        auto_update_opset=args.enable_auto_update_opset)
 
 
 if __name__ == "__main__":

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -97,7 +97,7 @@ def program2onnx(program,
             opset_version,
             enable_onnx_checker,
             operator_export_type,
-            auto_update_opset,
+            auto_update_opset=auto_update_opset,
             output_names=output_names)
     else:
         raise TypeError(


### PR DESCRIPTION
1. add enable_auto_update_opset choice, default is True
```
paddle2onnx --model_dir paddle_model  --model_filename model_filename --params_filename params_filename --save_file onnx_file --opset_version 10 --enable_onnx_checker True --enable_auto_update_opset False
```