### PR TITLE
remove some deprecate warning and enable test for dev version

### DIFF
--- a/paddle2onnx/constant/dtypes.py
+++ b/paddle2onnx/constant/dtypes.py
@@ -44,13 +44,13 @@ DTYPE_PADDLE_NUMPY_MAP = {
     np.int16: core.VarDesc.VarType.INT16,
     np.int32: core.VarDesc.VarType.INT32,
     np.int64: core.VarDesc.VarType.INT64,
-    np.bool: core.VarDesc.VarType.BOOL,
-    core.VarDesc.VarType.FP32: np.float,
+    np.bool_: core.VarDesc.VarType.BOOL,
+    core.VarDesc.VarType.FP32: np.float32,
     core.VarDesc.VarType.FP64: np.float64,
     core.VarDesc.VarType.INT16: np.int16,
     core.VarDesc.VarType.INT32: np.int32,
     core.VarDesc.VarType.INT64: np.int64,
-    core.VarDesc.VarType.BOOL: np.bool
+    core.VarDesc.VarType.BOOL: np.bool_
 }
 
 DTYPE_PADDLE_STR_MAP = {

--- a/paddle2onnx/cpp2py_export.cc
+++ b/paddle2onnx/cpp2py_export.cc
@@ -41,7 +41,7 @@ PYBIND11_MODULE(paddle2onnx_cpp2py_export, m) {
         return pybind11::bytes(onnx_proto);
       });
 
-  m.def("get_graph_op_list", [](const std::string& model_filename,
+  m.def("get_paddle_ops", [](const std::string& model_filename,
                                 const std::string& params_filename) {
     auto parser = PaddleParser();
     if (params_filename != "") {
@@ -65,6 +65,7 @@ PYBIND11_MODULE(paddle2onnx_cpp2py_export, m) {
     }
     return op_list;
   });
+
   // This interface can output all developed OPs and write them to the file_path
   m.def("get_all_registered_ops", [](const std::string& file_path) {
     int64_t total_ops = MapperHelper::Get()->GetAllOps(file_path);

--- a/paddle2onnx/mapper/tensor/fill_constant.h
+++ b/paddle2onnx/mapper/tensor/fill_constant.h
@@ -26,9 +26,11 @@ class FillConstantMapper : public Mapper {
   }
 
   int32_t GetMinOpset(bool verbose = false);
+  void Opset7();
   void Opset9();
 
  private:
+  float GetFillValue();
   std::string str_value_;
   float value_;
 };

--- a/tests/auto_scan_test.py
+++ b/tests/auto_scan_test.py
@@ -80,7 +80,7 @@ class OPConvertAutoScanTest(unittest.TestCase):
                        reproduce=None,
                        min_success_num=25,
                        max_duration=-1):
-        if os.getenv('HYPOTHESIS_TEST_PROFILE', 'ci') == "dev":
+        if os.getenv("CE_STAGE", "OFF") == "ON":
             max_examples *= 10
             min_success_num *= 10
             # while at ce phase, there's no limit on time

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -270,6 +270,21 @@ class APIOnnx(object):
         assert included is True, "{} op in not in convert OPs, all OPs :{}".format(
             self.ops, paddle_op_list)
 
+    def dev_check_ops(self, op_name, model_file_path):
+        from paddle.fluid.proto import framework_pb2
+        prog = framework_pb2.ProgramDesc()
+
+        with open(model_file_path, "rb") as f:
+            prog.ParseFromString(f.read())
+
+        ops = set()
+        find = False
+        for block in prog.blocks:
+            for op in block.ops:
+                if op.type == op_name:
+                    find = True
+        return find
+
     def run(self):
         """
         1. use dygraph layer to make exp
@@ -284,15 +299,52 @@ class APIOnnx(object):
 
             exp = self._mk_dygraph_exp(self._func)
             res_fict = {}
-            # export onnx models and make onnx res
-            for v in self._version:
-                self.check_ops(v)
-                self._dygraph_to_onnx(instance=self._func, ver=v)
-                res_fict[str(v)] = self._mk_onnx_res(ver=v)
+            if os.getenv("ENABLE_DEV", "OFF") == "OFF":
+                # export onnx models and make onnx res
+                for v in self._version:
+                    self.check_ops(v)
+                    self._dygraph_to_onnx(instance=self._func, ver=v)
+                    res_fict[str(v)] = self._mk_onnx_res(ver=v)
 
-            for v in self._version:
-                compare(res_fict[str(v)], exp, delta=self.delta, rtol=self.rtol)
+                for v in self._version:
+                    compare(
+                        res_fict[str(v)], exp, delta=self.delta, rtol=self.rtol)
 
-            # dygraph model jit save
-            if self.static is True and place == 'gpu':
-                self._dygraph_jit_save(instance=self._func)
+                # dygraph model jit save
+                if self.static is True and place == 'gpu':
+                    self._dygraph_jit_save(instance=self._func)
+            elif os.getenv("ENABLE_DEV", "OFF") == "ON":
+                assert len(
+                    self.ops
+                ) == 1, "Need to make sure the number of ops in config is 1."
+                import shutil
+                if os.path.exists(self.name):
+                    shutil.rmtree(self.name)
+                paddle.jit.save(self._func,
+                                os.path.join(self.name, "model"),
+                                self.input_spec)
+                self.dev_check_ops(self.ops[0],
+                                   os.path.join(self.name, "model.pdmodel"))
+                import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
+                model_file = os.path.join(self.name, "model.pdmodel")
+                params_file = os.path.join(self.name, "model.pdiparams")
+                if not os.path.exists(params_file):
+                    params_file = ""
+
+                min_opset_version = min(self._version)
+                max_opset_version = 15
+                for v in range(min_opset_version, 16):
+                    onnx_model_str = c_p2o.export(model_file, params_file, v,
+                                                  False, True, True, True, True)
+                    with open(
+                            os.path.join(self.name,
+                                         self.name + '_' + str(v) + ".onnx"),
+                            "wb") as f:
+                        f.write(onnx_model_str)
+                    res_fict[str(v)] = self._mk_onnx_res(ver=v)
+
+                for v in self._version:
+                    compare(
+                        res_fict[str(v)], exp, delta=self.delta, rtol=self.rtol)
+            else:
+                print("`export ENABLE_DEV=ON or export ENABLE_DEV=OFF`")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 onnx==1.8.0
 onnxruntime==1.10.0
-unittest
 hypothesis


### PR DESCRIPTION
- 移除了部分numpy带来的DeprecateWarning
- 单测支持新版本Paddle2ONNX，测试前`export ENABLE_DEV=ON`即可测试新版本代码