### PR TITLE
Fix quantize model export for TRT backend

### DIFF
--- a/paddle2onnx/mapper/quantize/dequantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/dequantize_linear.cc
@@ -129,9 +129,16 @@ void DequantizeLinearMapper::Opset10() {
          "Failed to read tensor value of `Scale`.");
   std::vector<float> onnx_scales;
   onnx_scales.reserve(scales.size());
+  bool all_positive = true;
   for (auto &i : scales) {
+    if (i <= 1e-10) all_positive = false;
     onnx_scales.push_back(i / 127);
   }
+  auto scale_info = GetInput("Scale");
+  Assert(all_positive,
+         "All scale values should be integers, but a negative scale was found "
+         "in the tensor: " +
+             scale_info[0].name + ".");
   std::vector<int64_t> onnx_zeros(onnx_scales.size(), 0);
   std::string scale_node, zero_node;
   if (onnx_zeros.size() == 1) {

--- a/paddle2onnx/mapper/quantize/dequantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/dequantize_linear.cc
@@ -129,19 +129,8 @@ void DequantizeLinearMapper::Opset10() {
          "Failed to read tensor value of `Scale`.");
   std::vector<float> onnx_scales;
   onnx_scales.reserve(scales.size());
-  bool all_positive = true;
   for (auto &i : scales) {
-    if (i <= 1e-10) all_positive = false;
     onnx_scales.push_back(i / 127);
-  }
-  if (!all_positive) {
-    Warn() << "Dequantize OP contains negative scale, so this scale info will "
-              "be discarded."
-           << std::endl;
-    auto out_info = GetOutput("Y");
-    helper_->AutoCast(x_info[0].name, out_info[0].name, x_info[0].dtype,
-                      out_info[0].dtype);
-    return;
   }
   std::vector<int64_t> onnx_zeros(onnx_scales.size(), 0);
   std::string scale_node, zero_node;

--- a/paddle2onnx/mapper/quantize/quantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/quantize_linear.cc
@@ -59,17 +59,7 @@ void QuantizeLinearMapper::Opset10() {
   onnx_scales.reserve(scales.size());
   bool all_positive = true;
   for (auto i : scales) {
-    if (i <= 1e-10) all_positive = false;
     onnx_scales.push_back(i / 127);
-  }
-  if (!all_positive) {
-    Warn() << "Quantize OP contains negative scale, so this scale info will be "
-              "discarded."
-           << std::endl;
-    auto out_info = GetOutput("Y");
-    helper_->AutoCast(x_info[0].name, out_info[0].name, x_info[0].dtype,
-                      out_info[0].dtype);
-    return;
   }
   std::vector<int64_t> onnx_zeros(onnx_scales.size(), 0);
 

--- a/paddle2onnx/mapper/quantize/quantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/quantize_linear.cc
@@ -57,9 +57,16 @@ void QuantizeLinearMapper::Opset10() {
          "Failed to read tensor value of `Scale`.");
   std::vector<float> onnx_scales;
   onnx_scales.reserve(scales.size());
+  bool all_positive = true;
   for (auto i : scales) {
+    if (i <= 1e-10) all_positive = false;
     onnx_scales.push_back(i / 127);
   }
+  auto scale_info = GetInput("Scale");
+  Assert(all_positive,
+         "All scale values should be integers, but a negative scale was found "
+         "in the tensor: " +
+             scale_info[0].name + ".");
   std::vector<int64_t> onnx_zeros(onnx_scales.size(), 0);
 
   std::string scale_node, zero_node;

--- a/paddle2onnx/mapper/quantize/quantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/quantize_linear.cc
@@ -57,7 +57,6 @@ void QuantizeLinearMapper::Opset10() {
          "Failed to read tensor value of `Scale`.");
   std::vector<float> onnx_scales;
   onnx_scales.reserve(scales.size());
-  bool all_positive = true;
   for (auto i : scales) {
     onnx_scales.push_back(i / 127);
   }

--- a/paddle2onnx/mapper/quantize/quantize_linear.cc
+++ b/paddle2onnx/mapper/quantize/quantize_linear.cc
@@ -62,11 +62,15 @@ void QuantizeLinearMapper::Opset10() {
     if (i <= 1e-10) all_positive = false;
     onnx_scales.push_back(i / 127);
   }
-  auto scale_info = GetInput("Scale");
-  Assert(all_positive,
-         "All scale values should be integers, but a negative scale was found "
-         "in the tensor: " +
-             scale_info[0].name + ".");
+  if (!all_positive) {
+    Warn() << "Quantize OP contains negative scale, so this scale info will be "
+              "discarded."
+           << std::endl;
+    auto out_info = GetOutput("Y");
+    helper_->AutoCast(x_info[0].name, out_info[0].name, x_info[0].dtype,
+                      out_info[0].dtype);
+    return;
+  }
   std::vector<int64_t> onnx_zeros(onnx_scales.size(), 0);
 
   std::string scale_node, zero_node;

--- a/paddle2onnx/mapper/quantize_helper.cc
+++ b/paddle2onnx/mapper/quantize_helper.cc
@@ -245,7 +245,11 @@ void QuantizeModelProcessor::AddTrtQDQ() {
       if (helper_->GetOpsetVersion() >= 13) {
         AddAttribute(dq_node, "axis", quantize_axis);
       }
-      ReplaceInputOfAllNodes(name, dq_node->output(0));
+      for (size_t i = 0; i < node->input_size(); ++i) {
+        if (node->input(i) == name) {
+          node->set_input(i, dq_node->output(0));
+        }
+      }
     }
   }
 }
@@ -984,4 +988,4 @@ void QuantizeModelProcessor::AppendQuantizeTensor(const std::string& tensor,
     }
   }
 }
-}
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/quantize_helper.cc
+++ b/paddle2onnx/mapper/quantize_helper.cc
@@ -222,15 +222,33 @@ void QuantizeModelProcessor::AddTrtQDQ() {
       }
       quantize_tensors = tensor_names;
     }
+
+    std::string negative_scale_tensor = "";
+    for (std::string& name : quantize_tensors) {
+      Assert(
+          helper_->quantize_info.find(name) != helper_->quantize_info.end(),
+          "[QuantizeModelProcessor] Can not find quantize info for tensor: " +
+              name);
+      QuantizeInfo quantize_info = helper_->quantize_info[name];
+      std::vector<float> scales = quantize_info.scale_;
+      for (auto i : scales) {
+        if (i <= 1e-10) {
+          negative_scale_tensor = negative_scale_tensor + " " + name;
+        }
+      }
+    }
+    if (negative_scale_tensor.size() > 0) {
+      P2OLogger()
+          << "[Warning] The scale of tensors: [ " + negative_scale_tensor +
+                 " ] contains negative scale, so this OP will not be quantized."
+          << std::endl;
+      continue;
+    }
     // An OP requires a separate quantize op
     for (std::string& name : quantize_tensors) {
       if (IsGraphOutput(name)) {
         continue;
       }
-      Assert(
-          helper_->quantize_info.find(name) != helper_->quantize_info.end(),
-          "[QuantizeModelProcessor] Can not find quantize info for tensor: " +
-              name);
       QuantizeInfo quantize_info = helper_->quantize_info[name];
       std::string scale_node = quantize_info.scale_node_;
       std::string zeros_node = quantize_info.zeros_node_;

--- a/paddle2onnx/mapper/quantize_helper.cc
+++ b/paddle2onnx/mapper/quantize_helper.cc
@@ -231,7 +231,7 @@ void QuantizeModelProcessor::AddTrtQDQ() {
               name);
       QuantizeInfo quantize_info = helper_->quantize_info[name];
       std::vector<float> scales = quantize_info.scale_;
-      for (auto i : scales) {
+      for (auto& i : scales) {
         if (i <= 1e-10) {
           negative_scale_tensor = negative_scale_tensor + " " + name;
         }


### PR DESCRIPTION
1. According to TRT's quantization tool, each quantized conv should have its own QDQ
2. Add scale value check，scales of QDQ must be positive, if a QDQ OP contains negative  scale value, discard it.