### PR TITLE
[OpAttr]Support to parse Attribute with type(Variable) in 2ONNX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@
 
 *.pyc
 .pydevproject
+build/*
+.eggs/*
+dist/*
+.setuptools*
+paddle2onnx.egg-info/*
+*.pdmodel
+*_*.onnx
+*.log
+version.py

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -176,6 +176,16 @@ class Mapper {
   std::vector<TensorInfo> GetOutput(const std::string& name) const {
     return parser_->GetOpOutput(block_idx_, op_idx_, name);
   }
+  // Judge whether Attribute(name)'s type is Var or Vars.
+  bool IsAttrVar(const std::string& name) const {
+    return parser_->OpIsAttrVar(block_idx_, op_idx_, name);
+  }
+
+  // Get TensorInfo(s) from Attribute Var or Vars.
+  std::vector<TensorInfo> GetAttrVar(const std::string& name) const {
+    return parser_->GetOpAttrVar(block_idx_, op_idx_, name);
+  }
+
   bool HasAttr(const std::string& name) const {
     auto& op = parser_->GetOpDesc(block_idx_, op_idx_);
     return parser_->OpHasAttr(op, name);
@@ -218,6 +228,11 @@ class Mapper {
   bool TryGetInputValue(const std::string& input_key, std::vector<T>* data) {
     auto input_info = GetInput(input_key);
     return parser_->TryGetTensorValue(block_idx_, input_info[0].name, data);
+  }
+
+  template <typename T>
+  bool TryGetValue(const TensorInfo& info, std::vector<T>* data) {
+    return parser_->TryGetTensorValue(block_idx_, info.name, data);
   }
 };
 

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -224,6 +224,10 @@ class Mapper {
     return parser_->IsConstantTensor(block_idx_, input_info[0].name);
   }
 
+  bool IsConstant(const TensorInfo& info) const {
+    return parser_->IsConstantTensor(block_idx_, info.name);
+  }
+
   template <typename T>
   bool TryGetInputValue(const std::string& input_key, std::vector<T>* data) {
     auto input_info = GetInput(input_key);

--- a/paddle2onnx/mapper/tensor/concat.cc
+++ b/paddle2onnx/mapper/tensor/concat.cc
@@ -28,6 +28,13 @@ int32_t ConcatMapper::GetMinOpset(bool verbose) {
               << std::endl;
       return -1;
     }
+  } else if (IsAttrVar("axis")) {
+    if (!IsConstant(GetAttrVar("axis")[0])) {
+      Error() << "While Attribute(axis)'s type is Tensor, it's not supported "
+                 "unless it's a constant tensor."
+              << std::endl;
+      return -1;
+    }
   }
   return 7;
 }
@@ -42,9 +49,7 @@ void ConcatMapper::Opset7() {
 
   auto parse_axis_value = [&](const TensorInfo& tensor_info, int64_t& axis) {
     std::vector<int64_t> value;
-    Assert(TryGetValue(tensor_info, &value),
-           "While concat has input AxisTensor, and it's not a constant tensor, "
-           "the model cannot be converted.");
+    TryGetValue(tensor_info, &value);
     axis = value[0];
   };
 

--- a/paddle2onnx/parser/parser.h
+++ b/paddle2onnx/parser/parser.h
@@ -156,6 +156,12 @@ class PaddleParser {
   std::vector<TensorInfo> GetOpOutput(int64_t block_id, int64_t op_id,
                                       const std::string& name) const;
 
+  bool OpIsAttrVar(int64_t block_id, int64_t op_id,
+                   const std::string& name) const;
+
+  std::vector<TensorInfo> GetOpAttrVar(int64_t block_id, int64_t op_id,
+                                       const std::string& name) const;
+
   bool OpHasAttr(const paddle2onnx::framework::proto::OpDesc& op,
                  const std::string& name) const;
 
@@ -184,6 +190,8 @@ class PaddleParser {
  private:
   // If the model has same output name in difference operators
   // will fail to convert
+  bool IsAttrVar(const paddle2onnx::framework::proto::OpDesc& op,
+                 const int64_t& attr_id) const;
   bool ExistsDumplicateTensorName() const;
   void GetBlocksVarName2Id();
   void GetBlocksOps();

--- a/paddle2onnx/proto/p2o_paddle.proto
+++ b/paddle2onnx/proto/p2o_paddle.proto
@@ -20,7 +20,9 @@ package paddle2onnx.framework.proto;
 //
 // Serailization and Deserialization codes should be modified in a way
 // that supports old versions following the version and compatibility policy.
-message Version { optional int64 version = 1 [ default = 0 ]; }
+message Version {
+  optional int64 version = 1 [default = 0];
+}
 
 enum AttrType {
   INT = 0;
@@ -36,6 +38,8 @@ enum AttrType {
   BLOCKS = 10;
   LONGS = 11;
   FLOAT64S = 12;
+  VAR = 13;
+  VARS = 14;
 }
 
 message ProcessMeshDesc {
@@ -48,7 +52,6 @@ message ProcessMeshDesc {
 // OpDesc describes an instance of a C++ framework::OperatorBase
 // derived class type.
 message OpDesc {
-
   message Attr {
     required string name = 1;
     required AttrType type = 2;
@@ -65,6 +68,8 @@ message OpDesc {
     repeated int32 blocks_idx = 14;
     repeated int64 longs = 15;
     repeated double float64s = 16;
+    optional string var_name = 17;
+    repeated string vars_name = 18;
   };
 
   message Var {
@@ -76,22 +81,21 @@ message OpDesc {
   repeated Var inputs = 1;
   repeated Var outputs = 2;
   repeated Attr attrs = 4;
-  optional bool is_target = 5 [ default = false ];
+  optional bool is_target = 5 [default = false];
 };
 
 // OpProto describes a C++ framework::OperatorBase derived class.
 message OpProto {
-
   // VarProto describes the C++ type framework::Variable.
   message Var {
     required string name = 1;
     required string comment = 2;
 
-    optional bool duplicable = 3 [ default = false ];
-    optional bool intermediate = 4 [ default = false ];
-    optional bool dispensable = 5 [ default = false ];
-    optional bool extra = 6 [ default = false ];
-    optional bool quant = 7 [ default = false ];
+    optional bool duplicable = 3 [default = false];
+    optional bool intermediate = 4 [default = false];
+    optional bool dispensable = 5 [default = false];
+    optional bool extra = 6 [default = false];
+    optional bool quant = 7 [default = false];
   }
 
   // AttrProto describes the C++ type Attribute.
@@ -102,9 +106,10 @@ message OpProto {
     // If that attribute is generated, it means the Paddle third
     // language binding has responsibility to fill that
     // attribute. End-User should not set that attribute.
-    optional bool generated = 4 [ default = false ];
-    optional bool extra = 5 [ default = false ];
-    optional bool quant = 6 [ default = false ];
+    optional bool generated = 4 [default = false];
+    optional bool extra = 5 [default = false];
+    optional bool quant = 6 [default = false];
+    optional bool support_tensor = 7 [default = false];
   }
 
   required string type = 1;
@@ -159,26 +164,30 @@ message VarType {
   message TensorDesc {
     // Should only be PODType. Is enforced in C++
     required Type data_type = 1;
-    repeated int64 dims = 2; // [UNK, 640, 480] is saved as [-1, 640, 480]
+    repeated int64 dims = 2;  // [UNK, 640, 480] is saved as [-1, 640, 480]
   }
   optional TensorDesc selected_rows = 2;
 
   message LoDTensorDesc {
     required TensorDesc tensor = 1;
-    optional int32 lod_level = 2 [ default = 0 ];
+    optional int32 lod_level = 2 [default = 0];
   }
   optional LoDTensorDesc lod_tensor = 3;
 
   message LoDTensorArrayDesc {
     required TensorDesc tensor = 1;
-    optional int32 lod_level = 2 [ default = 0 ];
+    optional int32 lod_level = 2 [default = 0];
   }
   optional LoDTensorArrayDesc tensor_array = 4;
 
-  message ReaderDesc { repeated LoDTensorDesc lod_tensor = 1; }
+  message ReaderDesc {
+    repeated LoDTensorDesc lod_tensor = 1;
+  }
   optional ReaderDesc reader = 5;
 
-  message Tuple { repeated Type element_type = 1; }
+  message Tuple {
+    repeated Type element_type = 1;
+  }
   optional Tuple tuple = 7;
 
   optional TensorDesc string = 8;
@@ -187,7 +196,6 @@ message VarType {
 }
 
 message VarDesc {
-
   message Attr {
     required string name = 1;
     required AttrType type = 2;
@@ -198,12 +206,12 @@ message VarDesc {
 
   required string name = 1;
   required VarType type = 2;
-  optional bool persistable = 3 [ default = false ];
+  optional bool persistable = 3 [default = false];
   // True if the variable is an input data and
   // have to check the feed data shape and dtype
-  optional bool need_check_feed = 4 [ default = false ];
-  optional bool is_parameter = 5 [ default = false ];
-  optional bool stop_gradient = 6 [ default = false ];
+  optional bool need_check_feed = 4 [default = false];
+  optional bool is_parameter = 5 [default = false];
+  optional bool stop_gradient = 6 [default = false];
   repeated Attr attrs = 7;
 }
 
@@ -212,12 +220,14 @@ message BlockDesc {
   required int32 parent_idx = 2;
   repeated VarDesc vars = 3;
   repeated OpDesc ops = 4;
-  optional int32 forward_block_idx = 5 [ default = -1 ];
+  optional int32 forward_block_idx = 5 [default = -1];
 }
 
 // In some cases, Paddle may perform operator definition iterations,
 // and the operator uses OpVersionMap for compatibility testing.
-message OpVersion { required int32 version = 1; }
+message OpVersion {
+  required int32 version = 1;
+}
 message OpVersionMap {
   message OpVersionPair {
     required string op_name = 1;
@@ -232,7 +242,7 @@ message OpVersionMap {
 // TODO(panyx0718): A model can have multiple programs. Need a
 // way to distinguish them. Maybe ID or name?
 message ProgramDesc {
-  reserved 2, 3; // For backward compatibility.
+  reserved 2, 3;  // For backward compatibility.
   repeated BlockDesc blocks = 1;
   optional Version version = 4;
   optional OpVersionMap op_version_map = 5;


### PR DESCRIPTION
### what's New?

+ 适配了主框架的Attribute支持Variable机制，在Concat 单值attr和 Tile 多值attr 验证了机制的正确性
+ 给 Mapper 和 Parser 底层类分别新增了两个必要的接口：IsAttrVar 和 GetAttrVar，用于各个映射mapper的便捷适配
+ 将2ONNX仓库的 framework.proto 更新为最新版本，与主框架保持一致
+ 更新了 .gitignore 配置，自动忽略 python setup.py install 后的文件跟踪，以及tests目录下的类似op_7.ONNX单测产出文件

### 正确性验证
在此回滚PR上：https://github.com/PaddlePaddle/Paddle/pull/44658 验证了两个单测的正确性：

+ test_auto_scan_concat.py
+ test_auto_scan_tile.py