### PR TITLE
Export dynamic dimension with string

### DIFF
--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -152,7 +152,12 @@ std::shared_ptr<ONNX_NAMESPACE::ValueInfoProto> MakeValueInfo(
   tensor_type_proto->set_elem_type(GetOnnxDtype(info.dtype));
   auto shape = tensor_type_proto->mutable_shape();
   for (auto& dim : info.shape) {
-    shape->add_dim()->set_dim_value(dim);
+    if (dim < 0) {
+      auto dynamic_dim_name = MapperHelper::Get()->GenName("DynamicDimension");
+      shape->add_dim()->set_dim_param(dynamic_dim_name);
+    } else {
+      shape->add_dim()->set_dim_value(dim);
+    }
   }
   return value_info;
 }

--- a/tests/test_quantize_model_speedup.py
+++ b/tests/test_quantize_model_speedup.py
@@ -67,7 +67,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             name = input_names[index]
             new_shape = []
             for i in shape:
-                if i is None or i <= 0:
+                if type(i) is str or i is None or i <= 0:
                     i = 1
                 new_shape.append(i)
             input_dict[name] = np.ones(new_shape, dtype="float32")

--- a/tests/test_quantize_model_speedup.py
+++ b/tests/test_quantize_model_speedup.py
@@ -67,7 +67,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             name = input_names[index]
             new_shape = []
             for i in shape:
-                if type(i) is str or i is None or i <= 0:
+                if isinstance(i, str) or i is None or i <= 0:
                     i = 1
                 new_shape.append(i)
             input_dict[name] = np.ones(new_shape, dtype="float32")


### PR DESCRIPTION
采用字符串表示动态维度。 由于Paddle模型中-1仅表示动态维度，无其它信息，因此在导出模型时，所有的-1使用不同的字符串来表示

相关issue: https://github.com/PaddlePaddle/Paddle2ONNX/issues/928