### PR TITLE
Enable BatchedNMS Plugin in TensorRT

### DIFF
--- a/paddle2onnx/mapper/detection/multiclass_nms.cc
+++ b/paddle2onnx/mapper/detection/multiclass_nms.cc
@@ -19,9 +19,6 @@ namespace paddle2onnx {
 REGISTER_MAPPER(multiclass_nms3, NMSMapper);
 
 int32_t NMSMapper::GetMinOpset(bool verbose) {
-  if (export_as_custom_op || this->deploy_backend == "tensorrt") {
-    return 7;
-  }
   auto boxes_info = GetInput("BBoxes");
   auto score_info = GetInput("Scores");
   if (score_info[0].Rank() != 3) {
@@ -36,6 +33,15 @@ int32_t NMSMapper::GetMinOpset(bool verbose) {
             << boxes_info[0].Rank() << "." << std::endl;
     return -1;
   }
+  if (score_info[0].shape[1] <= 0) {
+    Error() << "The 2nd-dimension of score should be fixed(means the number of classes), but now it's " << score_info[0].shape[1] << "." << std::endl;
+    return -1;
+  }
+
+  if (export_as_custom_op || this->deploy_backend == "tensorrt") {
+    return 7;
+  }
+
   if (boxes_info[0].shape[1] < 0 || boxes_info[0].shape[2] < 0) {
     Error() << "The 2-nd and 3-rd dimension of input bboxes tensor of "
                "multiclass_nms should be fixed, but now the shape is ["
@@ -276,15 +282,36 @@ void NMSMapper::ExportForTensorRT() {
   auto index_info = GetOutput("Index");
   auto num_rois_info = GetOutput("NmsRoisNum");
 
-  auto score = helper_->Transpose(score_info[0].name, {0, 2, 1});
-  auto nms_node = helper_->MakeNode("EfficientNMS_TRT", {boxes_info[0].name, score}, 4);
-  AddAttribute(nms_node, "plugin_version", "1");
-  AddAttribute(nms_node, "background_class", background_label_);
-  AddAttribute(nms_node, "max_output_boxes", keep_top_k_);
-  AddAttribute(nms_node, "score_threshold", score_threshold_);
-  AddAttribute(nms_node, "iou_threshold", nms_threshold_);
-  AddAttribute(nms_node, "score_activation", int64_t(0));
-  AddAttribute(nms_node, "box_coding", int64_t(0));
+  auto scores = helper_->Transpose(score_info[0].name, {0, 2, 1});
+  auto boxes = helper_->Unsqueeze(boxes_info[0].name, {2});
+  int64_t num_classes = score_info[0].shape[1];
+  auto repeats = helper_->Constant(GetOnnxDtype(P2ODataType::INT64), std::vector<int64_t>({1, 1, num_classes, 1}));
+  boxes = helper_->MakeNode("Tile", {boxes, repeats})->output(0);
+  
+  auto nms_node = helper_->MakeNode("BatchedNMSDynamic_TRT", {boxes, scores}, 4);
+  AddAttribute(nms_node, "shareLocation", int64_t(0));
+  AddAttribute(nms_node, "backgroundLabelId", background_label_);
+  AddAttribute(nms_node, "numClasses", num_classes);
+  int64_t nms_top_k = nms_top_k_;
+  int64_t keep_top_k = keep_top_k_;
+  if (nms_top_k > 4096) {
+    Warn() << "Paramter nms_top_k:" << nms_top_k << " is exceed limit in TensorRT BatchedNMS plugin, will force to 4096." << std::endl;
+    nms_top_k = 4096;
+  }
+  if (keep_top_k > 4096) {
+    Warn() << "Parameter keep_top_k:" << keep_top_k << " is exceed limit in TensorRT BatchedNMS plugin, will force to 4096." << std::endl;
+    keep_top_k = 4096;
+  }
+  AddAttribute(nms_node, "topK", nms_top_k);
+  AddAttribute(nms_node, "keepTopK", keep_top_k);
+  AddAttribute(nms_node, "scoreThreshold", score_threshold_);
+  AddAttribute(nms_node, "iouThreshold", nms_threshold_);
+  if (normalized_) {
+    AddAttribute(nms_node, "isNormalized", int64_t(1));
+  } else {
+    AddAttribute(nms_node, "isNormalized", int64_t(0));
+  }
+  AddAttribute(nms_node, "clipBoxes", int64_t(0));
   nms_node->set_domain("Paddle");
 
   auto num_rois = helper_->Reshape(nms_node->output(0), {-1});
@@ -295,6 +322,26 @@ void NMSMapper::ExportForTensorRT() {
   auto out_boxes = helper_->Reshape(nms_node->output(1), {-1, 4});
   out_classes = helper_->AutoCast(out_classes, P2ODataType::INT32, P2ODataType::FP32);
   helper_->Concat({out_classes, out_scores, out_boxes}, {out_info[0].name}, 1);
+
+//  EfficientNMS_TRT cannot get the same result, so disable now
+//  auto nms_node = helper_->MakeNode("EfficientNMS_TRT", {boxes_info[0].name, score}, 4);
+//  AddAttribute(nms_node, "plugin_version", "1");
+//  AddAttribute(nms_node, "background_class", background_label_);
+//  AddAttribute(nms_node, "max_output_boxes", nms_top_k_);
+//  AddAttribute(nms_node, "score_threshold", score_threshold_);
+//  AddAttribute(nms_node, "iou_threshold", nms_threshold_);
+//  AddAttribute(nms_node, "score_activation", int64_t(0));
+//  AddAttribute(nms_node, "box_coding", int64_t(0));
+//  nms_node->set_domain("Paddle");
+//
+//  auto num_rois = helper_->Reshape(nms_node->output(0), {-1});
+//  helper_->AutoCast(num_rois, num_rois_info[0].name, P2ODataType::INT32, num_rois_info[0].dtype);
+//
+//  auto out_classes = helper_->Reshape(nms_node->output(3), {-1, 1});
+//  auto out_scores = helper_->Reshape(nms_node->output(2), {-1, 1});
+//  auto out_boxes = helper_->Reshape(nms_node->output(1), {-1, 4});
+//  out_classes = helper_->AutoCast(out_classes, P2ODataType::INT32, P2ODataType::FP32);
+//  helper_->Concat({out_classes, out_scores, out_boxes}, {out_info[0].name}, 1);
 }
 
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/detection/multiclass_nms.cc
+++ b/paddle2onnx/mapper/detection/multiclass_nms.cc
@@ -276,7 +276,6 @@ void NMSMapper::ExportForTensorRT() {
   auto index_info = GetOutput("Index");
   auto num_rois_info = GetOutput("NmsRoisNum");
 
-  std::cout << "00000000" << std::endl;
   auto score = helper_->Transpose(score_info[0].name, {0, 2, 1});
   auto nms_node = helper_->MakeNode("EfficientNMS_TRT", {boxes_info[0].name, score}, 4);
   AddAttribute(nms_node, "plugin_version", "1");

--- a/paddle2onnx/mapper/detection/multiclass_nms.h
+++ b/paddle2onnx/mapper/detection/multiclass_nms.h
@@ -46,6 +46,7 @@ class NMSMapper : public Mapper {
   int32_t GetMinOpset(bool verbose = false);
   void KeepTopK(const std::string& selected_indices);
   void Opset10();
+  void ExportForTensorRT();
   void ExportAsCustomOp();
 
  private:

--- a/paddle2onnx/mapper/elementwise.cc
+++ b/paddle2onnx/mapper/elementwise.cc
@@ -72,6 +72,7 @@ void ElementWiseModMapper::Opset10() {
       auto times = helper_->MakeNode("Div", {input_x_info[0].name, input_y_info[0].name})->output(0);
       auto result = helper_->MakeNode("Mul", {input_y_info[0].name, times})->output(0);
       helper_->MakeNode("Sub", {input_x_info[0].name, result}, {output_info[0].name});
+      return;
     }
     auto mod_node =
         helper_->MakeNode("Mod", {input_x_info[0].name, input_y_info[0].name},

--- a/paddle2onnx/mapper/elementwise.cc
+++ b/paddle2onnx/mapper/elementwise.cc
@@ -67,6 +67,12 @@ void ElementWiseModMapper::Opset10() {
   int64_t fmod = 0;
   if (input_y_info[0].dtype == P2ODataType::INT32 ||
       input_y_info[0].dtype == P2ODataType::INT64) {
+    if (this->deploy_backend == "tensorrt") {
+      auto x = helper_->AutoCast(input_x_info[0].name, input_x_info[0].dtype, input_y_info[0].dtype);
+      auto times = helper_->MakeNode("Div", {input_x_info[0].name, input_y_info[0].name})->output(0);
+      auto result = helper_->MakeNode("Mul", {input_y_info[0].name, times})->output(0);
+      helper_->MakeNode("Sub", {input_x_info[0].name, result}, {output_info[0].name});
+    }
     auto mod_node =
         helper_->MakeNode("Mod", {input_x_info[0].name, input_y_info[0].name},
                           {output_info[0].name});

--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -87,6 +87,7 @@ void ModelExporter::ExportOp(const PaddleParser& parser, OnnxHelper* helper,
 
   auto mapper = MapperHelper::Get()->CreateMapper(op.type(), parser, helper,
                                                   block_id, op_id);
+  mapper->deploy_backend = _deploy_backend;
 #ifdef PADDLE2ONNX_DEBUG
   P2OLogger(true) << "Mapper Name: " << mapper->Name() << std::endl;
 #endif
@@ -177,6 +178,7 @@ std::string ModelExporter::Run(const PaddleParser& parser, int opset_version,
                                bool enable_optimize,
                                const std::string& deploy_backend,
                                std::string* calibration_cache) {
+  _deploy_backend = deploy_backend;
   _helper.SetOpsetVersion(opset_version);
   _total_ops_num = 0;
   _current_exported_num = 0;

--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -29,6 +29,8 @@ struct ModelExporter {
   std::vector<std::shared_ptr<ONNX_NAMESPACE::NodeProto>> parameters;
   std::vector<std::shared_ptr<ONNX_NAMESPACE::ValueInfoProto>> inputs;
   std::vector<std::shared_ptr<ONNX_NAMESPACE::ValueInfoProto>> outputs;
+  // The _deploy_backend will pass to Mapper to influence the conversion
+  std::string _deploy_backend = "onnxruntime";
   OnnxHelper _helper;
   int32_t _total_ops_num = 0;
   int32_t _current_exported_num = 0;
@@ -37,7 +39,7 @@ struct ModelExporter {
                         bool use_initializer = false);
 
   // Update constant node in parameters. When process quantize model, the weight
-  // dtype may be int8, it should be convet to float32 and use this func to
+  // dtype may be int8, it should be convet to float32 and use this function to
   // update converted params.
   void UpdateParameters(const std::map<std::string, Weight>& params);
   void ExportInputOutputs(const std::vector<TensorInfo>& input_infos,

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -39,6 +39,7 @@ class Mapper {
   bool export_as_custom_op = false;
   // [exported_op_name, domain]
   std::string custom_op_name;
+  std::string deploy_backend;
 
   P2OLogger Logger(const bool& verbose, const int32_t& opset_version = 100) {
     bool v = verbose;

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -152,7 +152,12 @@ std::shared_ptr<ONNX_NAMESPACE::ValueInfoProto> MakeValueInfo(
   tensor_type_proto->set_elem_type(GetOnnxDtype(info.dtype));
   auto shape = tensor_type_proto->mutable_shape();
   for (auto& dim : info.shape) {
-    shape->add_dim()->set_dim_value(dim);
+    if (dim < 0) {
+      auto dynamic_dim_name = MapperHelper::Get()->GenName("DynamicDimension");
+      shape->add_dim()->set_dim_param(dynamic_dim_name);
+    } else {
+      shape->add_dim()->set_dim_value(dim);
+    }
   }
   return value_info;
 }

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -341,6 +341,9 @@ std::string OnnxHelper::Reshape(const std::string& input,
   } else {
     auto shape_node = Constant(ONNX_NAMESPACE::TensorProto::INT64, shape);
     auto node = MakeNode("Reshape", {input, shape_node}, {output});
+    if (opset_version >= 14) {
+      AddAttribute(node, "allowzero", int64_t(0));
+    }
   }
   return output;
 }

--- a/paddle2onnx/onnx_reader.cc
+++ b/paddle2onnx/onnx_reader.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <set>
 #include <string>
+#include <cstring>
 #include "paddle2onnx/converter.h"
 #include "paddle2onnx/mapper/exporter.h"
 #include "paddle2onnx/optimizer/paddle2onnx_optimizer.h"

--- a/paddle2onnx/paddle_reader.cc
+++ b/paddle2onnx/paddle_reader.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <set>
 #include <string>
-
+#include <cstring>
 #include "paddle2onnx/converter.h"
 #include "paddle2onnx/mapper/exporter.h"
 #include "paddle2onnx/parser/parser.h"

--- a/tests/test_quantize_model_speedup.py
+++ b/tests/test_quantize_model_speedup.py
@@ -67,7 +67,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             name = input_names[index]
             new_shape = []
             for i in shape:
-                if i is None or i <= 0:
+                if isinstance(i, str) or i is None or i <= 0:
                     i = 1
                 new_shape.append(i)
             input_dict[name] = np.ones(new_shape, dtype="float32")


### PR DESCRIPTION
由于`Mod`不被TensorRT支持，当输入为INT类型时，`elementwise_mod`的转换逻辑改为
```
tmp0 = x // y
tmp1 = y * tmp0
result = x - tmp1
```