### PR TITLE
Fix bug for reshape operator

### DIFF
--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -224,7 +224,7 @@ def main():
             verbose=True,
             enable_onnx_checker=args.enable_onnx_checker,
             enable_experimental_op=True,
-            enable_optimize=False,
+            enable_optimize=True,
             deploy_backend=args.deploy_backend,
             calibration_file=calibration_file)
         logging.info("===============Make PaddlePaddle Better!================")

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -224,7 +224,7 @@ def main():
             verbose=True,
             enable_onnx_checker=args.enable_onnx_checker,
             enable_experimental_op=True,
-            enable_optimize=True,
+            enable_optimize=False,
             deploy_backend=args.deploy_backend,
             calibration_file=calibration_file)
         logging.info("===============Make PaddlePaddle Better!================")

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -18,6 +18,13 @@ namespace paddle2onnx {
 
 void AddAttribute(std::shared_ptr<ONNX_NAMESPACE::NodeProto> node,
                   const std::string& name, const int64_t& value) {
+  for (int i = 0; i < node->attribute_size(); ++i) {
+    if (node->attribute(i).name() == name) {
+      node->mutable_attribute(i)->set_i(value);
+      node->mutable_attribute(i)->set_type(ONNX_NAMESPACE::AttributeProto::INT);
+      return;
+    }
+  }
   auto attr = node->add_attribute();
   attr->set_name(name);
   attr->set_i(value);
@@ -26,6 +33,13 @@ void AddAttribute(std::shared_ptr<ONNX_NAMESPACE::NodeProto> node,
 
 void AddAttribute(std::shared_ptr<ONNX_NAMESPACE::NodeProto> node,
                   const std::string& name, const float& value) {
+  for (int i = 0; i < node->attribute_size(); ++i) {
+    if (node->attribute(i).name() == name) {
+      node->mutable_attribute(i)->set_f(value);
+      node->mutable_attribute(i)->set_type(ONNX_NAMESPACE::AttributeProto::FLOAT);
+      return;
+    }
+  }
   auto attr = node->add_attribute();
   attr->set_name(name);
   attr->set_f(value);
@@ -178,6 +192,10 @@ std::shared_ptr<ONNX_NAMESPACE::NodeProto> OnnxHelper::MakeNode(
   for (size_t i = 0; i < outputs.size(); ++i) {
     node->add_output(outputs[i]);
   }
+  if (op_type == "Reshape" && GetOpsetVersion() >= 14) {
+    AddAttribute(node, "allowzero", int64_t(0));
+  }
+
   nodes.push_back(node);
   return node;
 }
@@ -201,6 +219,9 @@ std::shared_ptr<ONNX_NAMESPACE::NodeProto> OnnxHelper::MakeNode(
   }
   for (size_t i = 0; i < outputs.size(); ++i) {
     node->add_output(outputs[i]);
+  }
+  if (op_type == "Reshape" && GetOpsetVersion() >= 14) {
+    AddAttribute(node, "allowzero", int64_t(0));
   }
   nodes.push_back(node);
   return node;


### PR DESCRIPTION
- Reshape Operator在OpsetVersion >= 14时，要求allowzero属性。在这个PR中统一添加
- 解决在DINO模型中， BOOLEAN类型数据相乘不被Mul支持的问题
解决此issue https://github.com/PaddlePaddle/Paddle2ONNX/issues/939