### PR TITLE
Support export custom ops by user

### DIFF
--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -129,6 +129,12 @@ def arg_parser():
         type=ast.literal_eval,
         default=False,
         help="Whether export FP16 model for ORT-GPU, default False")
+    parser.add_argument(
+        "--custom_ops",
+        type=_text_type,
+        default={},
+        help="Ops that needs to be converted to custom op, e.g --custom_ops '{\"paddle_op\":\"onnx_op\"}', default {}"
+    )
     return parser
 
 
@@ -144,12 +150,14 @@ def c_paddle_to_onnx(model_file,
                      deploy_backend="onnxruntime",
                      calibration_file="",
                      external_file="",
-                     export_fp16_model=False):
+                     export_fp16_model=False,
+                     custom_ops={}):
     import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
     onnx_model_str = c_p2o.export(
         model_file, params_file, opset_version, auto_upgrade_opset, verbose,
-        enable_onnx_checker, enable_experimental_op, enable_optimize, {},
-        deploy_backend, calibration_file, external_file, export_fp16_model)
+        enable_onnx_checker, enable_experimental_op, enable_optimize,
+        custom_ops, deploy_backend, calibration_file, external_file,
+        export_fp16_model)
     if save_file is not None:
         with open(save_file, "wb") as f:
             f.write(onnx_model_str)
@@ -235,6 +243,8 @@ def main():
             os.mkdir(base_path)
         external_file = os.path.join(base_path, args.external_filename)
 
+        custom_ops_dict = eval(args.custom_ops)
+
         calibration_file = args.save_calibration_file
         c_paddle_to_onnx(
             model_file=model_file,
@@ -249,7 +259,8 @@ def main():
             deploy_backend=args.deploy_backend,
             calibration_file=calibration_file,
             external_file=external_file,
-            export_fp16_model=args.export_fp16_model)
+            export_fp16_model=args.export_fp16_model,
+            custom_ops=custom_ops_dict)
         logging.info("===============Make PaddlePaddle Better!================")
         logging.info("A little survey: https://iwenjuan.baidu.com/?code=r8hu2s")
         return

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -132,7 +132,7 @@ def arg_parser():
     parser.add_argument(
         "--custom_ops",
         type=_text_type,
-        default={},
+        default="{}",
         help="Ops that needs to be converted to custom op, e.g --custom_ops '{\"paddle_op\":\"onnx_op\"}', default {}"
     )
     return parser

--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -74,6 +74,80 @@ void ModelExporter::ExportInputOutputs(
   }
 }
 
+void ModelExporter::CovertCustomOps(const PaddleParser& parser,
+                                    OnnxHelper* helper, int64_t block_id,
+                                    int64_t op_id) {
+  auto op = parser.GetOpDesc(block_id, op_id);
+  std::vector<std::string> input_strs;
+  for (auto i_index = 0; i_index < op.inputs_size(); i_index++) {
+    auto input = op.inputs(i_index);
+    std::string parameter = input.parameter();
+    if (parser.OpHasInput(block_id, op_id, parameter)) {
+      auto input_info = parser.GetOpInput(block_id, op_id, parameter);
+      for (auto input : input_info) {
+        input_strs.push_back(input.name);
+        helper->MakeValueInfo(input.name, input.dtype, input.shape);
+      }
+    }
+  }
+  std::vector<std::string> output_strs;
+  for (auto o_index = 0; o_index < op.outputs_size(); o_index++) {
+    auto output = op.outputs(o_index);
+    std::string parameter = output.parameter();
+    if (parser.OpHasOutput(block_id, op_id, parameter)) {
+      auto output_info = parser.GetOpOutput(block_id, op_id, parameter);
+      for (auto output : output_info) {
+        output_strs.push_back(output.name);
+        helper->MakeValueInfo(output.name, output.dtype, output.shape);
+      }
+    }
+  }
+  auto node = helper->MakeNode(custom_ops[op.type()], input_strs, output_strs);
+  node->set_domain("Paddle");
+  for (auto attr_index = 0; attr_index < op.attrs_size(); attr_index++) {
+    auto attr = op.attrs(attr_index);
+    std::string attr_name = attr.name();
+    if (attr_name == "op_callstack") {
+      continue;
+    }
+    if (attr.has_i() || attr.has_l()) {
+      int64_t val;
+      parser.GetOpAttr(op, attr_name, &val);
+      AddAttribute(node, attr_name, val);
+    } else if (attr.has_f()) {
+      float val;
+      parser.GetOpAttr(op, attr_name, &val);
+      AddAttribute(node, attr_name, val);
+    } else if (attr.has_b()) {
+      bool val;
+      parser.GetOpAttr(op, attr_name, &val);
+      AddAttribute(node, attr_name, static_cast<int64_t>(val));
+    } else if (attr.has_s()) {
+      std::string val;
+      parser.GetOpAttr(op, attr_name, &val);
+      AddAttribute(node, attr_name, val);
+    } else if (attr.ints_size() > 0 || attr.longs_size() > 0) {
+      std::vector<int64_t> vec;
+      parser.GetOpAttr(op, attr_name, &vec);
+      AddAttribute(node, attr_name, vec);
+    } else if (attr.floats_size() > 0) {
+      std::vector<float> vec;
+      parser.GetOpAttr(op, attr_name, &vec);
+      AddAttribute(node, attr_name, vec);
+    } else if (attr.float64s_size() > 0) {
+      std::vector<double> vec;
+      parser.GetOpAttr(op, attr_name, &vec);
+      std::vector<float> fp32_vec;
+      for (auto val : vec) {
+        fp32_vec.push_back(static_cast<float>(val));
+      }
+      AddAttribute(node, attr_name, fp32_vec);
+    }
+  }
+  P2OLogger(true) << op.type() << " is exported as custom operator: "
+                  << custom_ops[op.type()] << std::endl;
+}
+
 void ModelExporter::ExportOp(const PaddleParser& parser, OnnxHelper* helper,
                              int32_t opset_version, int64_t block_id,
                              int64_t op_id, bool verbose) {
@@ -87,20 +161,24 @@ void ModelExporter::ExportOp(const PaddleParser& parser, OnnxHelper* helper,
     return ExportLoop(parser, helper, opset_version, block_id, op_id, verbose);
   }
 
-  auto mapper = MapperHelper::Get()->CreateMapper(op.type(), parser, helper,
-                                                  block_id, op_id);
-  mapper->deploy_backend = _deploy_backend;
+  if (MapperHelper::Get()->IsRegistered(op.type())) {
+    auto mapper = MapperHelper::Get()->CreateMapper(op.type(), parser, helper,
+                                                    block_id, op_id);
+    mapper->deploy_backend = _deploy_backend;
 #ifdef PADDLE2ONNX_DEBUG
-  P2OLogger(true) << "Mapper Name: " << mapper->Name() << std::endl;
+    P2OLogger(true) << "Mapper Name: " << mapper->Name() << std::endl;
 #endif
-  // Some operators will export as custom operator
-  auto iter = custom_ops.find(op.type());
-  if (iter != custom_ops.end()) {
-    mapper->export_as_custom_op = true;
-    mapper->custom_op_name = iter->second;
+    // Some operators will export as custom operator
+    auto iter = custom_ops.find(op.type());
+    if (iter != custom_ops.end()) {
+      mapper->export_as_custom_op = true;
+      mapper->custom_op_name = iter->second;
+    }
+    mapper->Run();
+    delete mapper;
+  } else if (custom_ops.find(op.type()) != custom_ops.end()) {
+    CovertCustomOps(parser, helper, block_id, op_id);
   }
-  mapper->Run();
-  delete mapper;
 
 #ifdef PADDLE2ONNX_DEBUG
   P2OLogger(true) << "---Converting operator: " << op.type() << " done---"
@@ -427,6 +505,9 @@ bool ModelExporter::CheckIfOpSupported(const PaddleParser& parser,
         if (!IsLoopSupported(parser, i, j)) {
           unsupported_ops->insert("while");
         }
+        continue;
+      }
+      if (custom_ops.find(op.type()) != custom_ops.end()) {
         continue;
       }
       if (!MapperHelper::Get()->IsRegistered(op.type())) {

--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -66,7 +66,8 @@ struct ModelExporter {
   void ExportLoop(const PaddleParser& parser, OnnxHelper* helper,
                   int32_t opset_version, int64_t block_id, int64_t op_id,
                   bool verbose);
-
+  void CovertCustomOps(const PaddleParser& parser, OnnxHelper* helper,
+                       int64_t block_id, int64_t op_id);
   ONNX_NAMESPACE::ModelProto Optimize(const ONNX_NAMESPACE::ModelProto& model);
 
  public:

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -74,7 +74,7 @@ void AddAttribute(std::shared_ptr<ONNX_NAMESPACE::NodeProto> node,
   for (auto& item : values) {
     attr->add_floats(item);
   }
-  attr->set_type(ONNX_NAMESPACE::AttributeProto::FLOAT);
+  attr->set_type(ONNX_NAMESPACE::AttributeProto::FLOATS);
 }
 
 void AddAttribute(std::shared_ptr<ONNX_NAMESPACE::NodeProto> node,


### PR DESCRIPTION
Support export custom ops by user

Use the following command to convert the specified Paddle OP to Custom ONNX OP：
```
paddle2onnx --model_dir ./ --model_filename bevpool.pdmodel --params_filename bevpool.pdiparams --save_file model.onnx --opset_version 13 --enable_onnx_checker True --custom_ops '{"bev_pool_v2":"bev_pool_v2","atan2":"atan2"}'
```