### PR TITLE
[0D Tensor] Add 0D tensor input support for 35 element-wise ops

### DIFF
--- a/paddle2onnx/mapper/activation.cc
+++ b/paddle2onnx/mapper/activation.cc
@@ -332,13 +332,8 @@ void SoftMaxMapper::Opset13() {
 
 void BReluMapper::Opset7() {
   auto x_info = GetInput("X");
-  if (x_info[0].Rank() == 0) {
-    auto node = helper_->Clip(x_info[0].name, t_min_, t_max_, x_info[0].dtype);
-    helper_->Squeeze(node, GetOutput("Out")[0].name, {0});
-  } else {
-    helper_->Clip(x_info[0].name, GetOutput("Out")[0].name, t_min_, t_max_,
-                  x_info[0].dtype);
-  }
+  helper_->Clip(x_info[0], GetOutput("Out")[0].name, t_min_, t_max_,
+                x_info[0].dtype);
 }
 
 void EluMapper::Opset7() {
@@ -348,14 +343,16 @@ void EluMapper::Opset7() {
 }
 
 void HardShrinkMapper::Opset9() {
-  auto node = helper_->MakeNode("Shrink", {GetInput("X")[0].name});
-  AddAttribute(node, "lambd", threshold_);
-  AddAttribute(node, "bias", float(0.0));
   if (GetInput("X")[0].Rank() == 0) {
+    auto node = helper_->MakeNode("Shrink", {GetInput("X")[0].name});
+    AddAttribute(node, "lambd", threshold_);
+    AddAttribute(node, "bias", float(0.0));
     helper_->Squeeze(node->output(0), GetOutput("Out")[0].name, {0});
   } else {
-    helper_->AutoCast(node->output(0), GetOutput("Out")[0].name,
-                      GetInput("X")[0].dtype, GetOutput("Out")[0].dtype);
+    auto node = helper_->MakeNode("Shrink", {GetInput("X")[0].name},
+                                  {GetOutput("Out")[0].name});
+    AddAttribute(node, "lambd", threshold_);
+    AddAttribute(node, "bias", float(0.0));
   }
 }
 

--- a/paddle2onnx/mapper/activation.cc
+++ b/paddle2onnx/mapper/activation.cc
@@ -121,14 +121,8 @@ void Relu6Mapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
   float min = 0.0;
-  if (input_info[0].Rank() == 0) {
-    auto node =
-        helper_->Clip(input_info[0].name, min, threshold_, input_info[0].dtype);
-    helper_->Squeeze(node, output_info[0].name, {0});
-  } else {
-    helper_->Clip(input_info[0].name, output_info[0].name, min, threshold_,
-                  input_info[0].dtype);
-  }
+  helper_->Clip(input_info[0], output_info[0].name, min, threshold_,
+                input_info[0].dtype);
 }
 
 int32_t PReluMapper::GetMinOpset(bool verbose) {
@@ -183,14 +177,15 @@ void PReluMapper::Opset7() {
 void SeluMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
-  auto node = helper_->MakeNode("Selu", {input_info[0].name});
-  AddAttribute(node, "alpha", alpha_);
-  AddAttribute(node, "gamma", scale_);
   if (input_info[0].Rank() == 0) {
+    auto node = helper_->MakeNode("Selu", {input_info[0].name});
+    AddAttribute(node, "alpha", alpha_);
     helper_->Squeeze(node->output(0), output_info[0].name, {0});
   } else {
-    helper_->AutoCast(node->output(0), output_info[0].name, input_info[0].dtype,
-                      output_info[0].dtype);
+    auto node =
+        helper_->MakeNode("Selu", {input_info[0].name}, {output_info[0].name});
+    AddAttribute(node, "alpha", alpha_);
+    AddAttribute(node, "gamma", scale_);
   }
 }
 
@@ -254,13 +249,14 @@ void HardSwishMapper::Opset14() {
 void LeakyReluMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
-  auto node = helper_->MakeNode("LeakyRelu", {input_info[0].name});
-  AddAttribute(node, "alpha", alpha_);
   if (input_info[0].Rank() == 0) {
+    auto node = helper_->MakeNode("LeakyRelu", {input_info[0].name});
+    AddAttribute(node, "alpha", alpha_);
     helper_->Squeeze(node->output(0), output_info[0].name, {0});
   } else {
-    helper_->AutoCast(node->output(0), output_info[0].name, input_info[0].dtype,
-                      output_info[0].dtype);
+    auto node = helper_->MakeNode("LeakyRelu", {input_info[0].name},
+                                  {output_info[0].name});
+    AddAttribute(node, "alpha", alpha_);
   }
 }
 

--- a/paddle2onnx/mapper/onnx_helper.cc
+++ b/paddle2onnx/mapper/onnx_helper.cc
@@ -330,6 +330,26 @@ std::string OnnxHelper::Clip(const std::string& input, const float& min,
   return Clip(input, output, min, max, in_dtype);
 }
 
+std::string OnnxHelper::Clip(const TensorInfo& input_info,
+                             const std::string& output_name, const float& min,
+                             const float& max, const int32_t& in_dtype) {
+  std::string node_output;
+  if (input_info.Rank() == 0) {
+    std::string output = MapperHelper::Get()->GenName("helper.clip");
+    std::string clip_node = Clip(input_info.name, output, min, max, in_dtype);
+    node_output = Squeeze(clip_node, output_name, {0});
+  } else {
+    node_output = Clip(input_info.name, output_name, min, max, in_dtype);
+  }
+  return node_output;
+}
+
+std::string OnnxHelper::Clip(const TensorInfo& input_info, const float& min,
+                             const float& max, const int32_t& in_dtype) {
+  std::string output = MapperHelper::Get()->GenName("helper.clip");
+  return Clip(input_info, output, min, max, in_dtype);
+}
+
 std::string OnnxHelper::Squeeze(const std::string& input,
                                 const std::string& output,
                                 const std::vector<int64_t>& axes) {

--- a/paddle2onnx/mapper/onnx_helper.h
+++ b/paddle2onnx/mapper/onnx_helper.h
@@ -126,6 +126,10 @@ class OnnxHelper {
                    const int32_t& in_dtype);
   std::string Clip(const std::string& input, const std::string& output,
                    const float& min, const float& max, const int32_t& in_dtype);
+  std::string Clip(const TensorInfo& input_info, const float& min,
+                   const float& max, const int32_t& in_dtype);
+  std::string Clip(const TensorInfo& input_info, const std::string& output_name,
+                   const float& min, const float& max, const int32_t& in_dtype);
   std::string Squeeze(const std::string& input,
                       const std::vector<int64_t>& axes);
   std::string Squeeze(const std::string& input, const std::string& output,

--- a/tests/test_auto_scan_leakyrelu.py
+++ b/tests/test_auto_scan_leakyrelu.py
@@ -44,7 +44,7 @@ class TestLeakyreluConvert(OPConvertAutoScanTest):
         input_shape = draw(
             st.lists(
                 st.integers(
-                    min_value=10, max_value=20), min_size=1, max_size=4))
+                    min_value=10, max_value=20), min_size=0, max_size=4))
 
         dtype = draw(st.sampled_from(["float32"]))
         negative_slope = draw(st.floats(min_value=0, max_value=1))

--- a/tests/test_auto_scan_unary_ops.py
+++ b/tests/test_auto_scan_unary_ops.py
@@ -110,7 +110,6 @@ class TestUnaryOPConvert(OPConvertAutoScanTest):
                     min_value=2, max_value=20), min_size=0, max_size=4))
 
         data_shapes = input_shape
-        # input_specs = [-1, input_shape[1], -1, -1]
         input_specs = []
         dtype = draw(st.sampled_from(["float32"]))
         config = {

--- a/tests/test_auto_scan_unary_ops.py
+++ b/tests/test_auto_scan_unary_ops.py
@@ -107,17 +107,18 @@ class TestUnaryOPConvert(OPConvertAutoScanTest):
         input_shape = draw(
             st.lists(
                 st.integers(
-                    min_value=2, max_value=20), min_size=4, max_size=4))
+                    min_value=2, max_value=20), min_size=0, max_size=4))
 
         data_shapes = input_shape
-        input_specs = [-1, input_shape[1], -1, -1]
+        # input_specs = [-1, input_shape[1], -1, -1]
+        input_specs = []
         dtype = draw(st.sampled_from(["float32"]))
         config = {
             "op_names": "",
             "test_data_shapes": [data_shapes],
             "test_data_types": [[dtype]],
             "opset_version": [7, 9, 15],
-            "input_spec_shape": [input_specs],
+            "input_spec_shape": [],
         }
         models = list()
         op_names = list()


### PR DESCRIPTION
relu、relu6、tanh、log、sigmoid、sqrt、softplus、exp、floor、cos、sin、round、abs、acos、asin、atan、sinh、tan、ceil、cosh、softsign、sign、erf、reciprocal、leaky_relu、selu、swish、brelu、hard_shrink、square、rsqrt、log1p、log2、log10、silu