### PR TITLE
cleanup to CMakeLists.txt, this includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,22 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
-
 PROJECT(paddle2onnx C CXX)
-
-include(cmake/utils.cmake)
-
-ADD_SUBDIRECTORY(paddle2onnx)
+# ONNX 1.16 requires C++17
+set(CMAKE_CXX_STANDARD 17)
+# Build the libraries with -fPIC
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(WITH_STATIC "Compile Paddle2ONNX with  STATIC" OFF)
 option(PADDLE2ONNX_DEBUG "If open the debug log while converting model" OFF)
 option(MSVC_STATIC_CRT "Compile Paddle2ONNX with  MSVC STATIC CRT" ON)
-set(ONNX_CUSTOM_PROTOC_PATH "" CACHE STRING "Set yourself Protobufc path")
+
+if (PADDLE2ONNX_DEBUG)
+    add_definitions(-DPADDLE2ONNX_DEBUG)
+endif ()
+
+# Set max opset version for onnx if you build from other version of onnx this should be modified.
+# Refer to https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
+add_definitions(-DMAX_ONNX_OPSET_VERSION=19)
+add_definitions(-DPADDLE2ONNX_LIB)
 
 # Internal flags for convert.h.in
 set(WITH_PADDLE2ONNX_STATIC_INTERNAL OFF)
@@ -18,21 +25,8 @@ if (WITH_STATIC)
     add_definitions(-DWITH_PADDLE2ONNX_STATIC_INTERNAL_AT_COMPILING)
 endif ()
 
+include(cmake/utils.cmake)
 configure_file(${PROJECT_SOURCE_DIR}/paddle2onnx/mappers_registry.h.in ${PROJECT_SOURCE_DIR}/paddle2onnx/mappers_registry.h)
-
-if (PADDLE2ONNX_DEBUG)
-    add_definitions(-DPADDLE2ONNX_DEBUG)
-endif ()
-
-# Set C++14 as standard for the whole project
-if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-endif ()
-
-# Set max opset version for onnx if you build from other version of onnx this should be modified.
-# Refer to https://github.com/onnx/onnx/blob/main/docs/Versioning.md#released-versions
-add_definitions(-DMAX_ONNX_OPSET_VERSION=19)
-add_definitions(-DPADDLE2ONNX_LIB)
 
 # Third dependency: onnx
 if (NOT TARGET onnx_proto)
@@ -40,26 +34,10 @@ if (NOT TARGET onnx_proto)
         set(ONNX_NAMESPACE "onnx")
     endif ()
     add_definitions("-DONNX_NAMESPACE=${ONNX_NAMESPACE}")
-
-    if (ONNX_CUSTOM_PROTOC_PATH)
-        if (WIN32)
-            if (MSVC_STATIC_CRT)
-                # MT
-                set(ONNX_USE_MSVC_STATIC_RUNTIME ON)
-            else ()
-                # MD
-                set(ONNX_USE_MSVC_STATIC_RUNTIME OFF)
-            endif ()
-            set(ONNX_CUSTOM_PROTOC_PATH "${ONNX_CUSTOM_PROTOC_PATH};$ENV{PATH}")
-        else ()
-            set(ONNX_CUSTOM_PROTOC_PATH "${ONNX_CUSTOM_PROTOC_PATH}:$ENV{PATH}")
-        endif ()
-        set(ENV{PATH} ${ONNX_CUSTOM_PROTOC_PATH})
-    endif ()
-
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/onnx)
 endif ()
+
+# generate Paddle2ONNX proto files
 add_subdirectory(${PROJECT_SOURCE_DIR}/paddle2onnx/proto)
 
 include_directories(${PROJECT_SOURCE_DIR})
@@ -70,9 +48,9 @@ file(GLOB_RECURSE ALL_SRCS ${PROJECT_SOURCE_DIR}/paddle2onnx/*.cc ${PROJECT_SOUR
 list(REMOVE_ITEM ALL_SRCS ${PROJECT_SOURCE_DIR}/paddle2onnx/cpp2py_export.cc)
 list(REMOVE_ITEM ALL_SRCS ${PROJECT_SOURCE_DIR}/third_party/optimizer/onnxoptimizer/cpp2py_export.cc)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 file(READ "${PROJECT_SOURCE_DIR}/VERSION_NUMBER" PADDLE2ONNX_VERSION)
 string(STRIP "${PADDLE2ONNX_VERSION}" PADDLE2ONNX_VERSION)
+
 if (WITH_STATIC)
     # Here, we use a dummy target (paddle2onnx_dummy)
     # to form a build dependency tree for paddle2onnx_static lib.
@@ -130,17 +108,6 @@ install(
         DESTINATION include/paddle2onnx
 )
 
-
-if (BUILD_PADDLE2ONNX_EXE)
-    remove_definitions(-DPADDLE2ONNX_LIB)
-    ADD_EXECUTABLE(p2o_exec p2o_exec.cpp)
-    if (WITH_STATIC)
-        TARGET_LINK_LIBRARIES(p2o_exec -Wl,--whole-archive paddle2onnx -Wl,--no-whole-archive)
-    else ()
-        TARGET_LINK_LIBRARIES(p2o_exec paddle2onnx)
-    endif ()
-endif (BUILD_PADDLE2ONNX_EXE)
-
 if (BUILD_PADDLE2ONNX_PYTHON)
     if ("${PY_EXT_SUFFIX}" STREQUAL "")
         if (MSVC)
@@ -148,15 +115,6 @@ if (BUILD_PADDLE2ONNX_PYTHON)
         else ()
             set(PY_EXT_SUFFIX ".so")
         endif ()
-    endif ()
-
-    # find_package Python has replaced PythonInterp and PythonLibs since cmake 3.12
-    # Use the following command in the future; now this is only compatible with the latest pybind11
-#     find_package(Python ${PY_VERSION} COMPONENTS Interpreter Development REQUIRED)
-    find_package(PythonInterp ${PY_VERSION} REQUIRED)
-    find_package(PythonLibs ${PY_VERSION})
-    if (CMAKE_SYSTEM_NAME STREQUAL "AIX")
-        set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
     endif ()
 
     add_library(paddle2onnx_cpp2py_export MODULE ${PROJECT_SOURCE_DIR}/paddle2onnx/cpp2py_export.cc ${ALL_SRCS})
@@ -182,9 +140,6 @@ if (BUILD_PADDLE2ONNX_PYTHON)
     elseif (MSVC)
         # In MSVC, we will add whole archive in default
         target_link_libraries(paddle2onnx_cpp2py_export PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:onnx>)
-    elseif (CMAKE_SYSTEM_NAME STREQUAL "AIX")
-        # whole-archive linker option not available on AIX
-        target_sources(paddle2onnx_cpp2py_export PRIVATE $<TARGET_OBJECTS:onnx>)
     else ()
         # Assume everything else is like gcc
         target_link_libraries(paddle2onnx_cpp2py_export PRIVATE "-Wl,--whole-archive" $<TARGET_FILE:onnx> "-Wl,--no-whole-archive")


### PR DESCRIPTION
- removed ONNX_CUSTOM_PROTOC_PATH section, since we always use developer compiled protobuf
- removed BUILD_PADDLE2ONNX_EXE section, since `p2o_exec.cpp` doesn't exist
- removed AIX compile branch,  since supporting AIX platform is not in the project's scope.
- other minor changes