### PR TITLE
[API]Remove depreacate API and Expose convert.dygraph2onnx

### DIFF
--- a/paddle2onnx/__init__.py
+++ b/paddle2onnx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022  PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2024  PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"
 # you may not use this file except in compliance with the License.
@@ -12,39 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .version import version
+from .convert import export
+from .convert import dygraph2onnx
 
 __version__ = version
-
-
-def export(model_file,
-           params_file="",
-           save_file=None,
-           opset_version=11,
-           auto_upgrade_opset=True,
-           verbose=True,
-           enable_onnx_checker=True,
-           enable_experimental_op=True,
-           enable_optimize=True,
-           custom_op_info=None,
-           deploy_backend="onnxruntime",
-           calibration_file="",
-           external_file="",
-           export_fp16_model=False):
-    import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
-    deploy_backend = deploy_backend.lower()
-    if custom_op_info is None:
-        onnx_model_str = c_p2o.export(
-            model_file, params_file, opset_version, auto_upgrade_opset, verbose,
-            enable_onnx_checker, enable_experimental_op, enable_optimize, {},
-            deploy_backend, calibration_file, external_file, export_fp16_model)
-    else:
-        onnx_model_str = c_p2o.export(
-            model_file, params_file, opset_version, auto_upgrade_opset, verbose,
-            enable_onnx_checker, enable_experimental_op, enable_optimize,
-            custom_op_info, deploy_backend, calibration_file, external_file,
-            export_fp16_model)
-    if save_file is not None:
-        with open(save_file, "wb") as f:
-            f.write(onnx_model_str)
-    else:
-        return onnx_model_str

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import os
+import paddle
+import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
+from paddle2onnx.utils import logging, paddle_jit_save_configs
 
 def export(model_file,
            params_file="",
@@ -28,7 +31,6 @@ def export(model_file,
            calibration_file="",
            external_file="",
            export_fp16_model=False):
-    import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
     deploy_backend = deploy_backend.lower()
     if custom_op_info is None:
         onnx_model_str = c_p2o.export(
@@ -48,12 +50,10 @@ def export(model_file,
         return onnx_model_str
 
 
-def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
-    import paddle
-    from paddle2onnx.utils import logging, paddle_jit_save_configs
+def dygraph2onnx(layer, save_file, input_spec=None, opset_version=11, **configs):
     # Get PaddleInference model file path
     dirname = os.path.split(save_file)[0]
-    paddle_model_dir = os.path.join(dirname, "paddle_model_static_onnx_temp_dir")
+    paddle_model_dir = os.path.join(dirname, "paddle_model_temp_dir")
     model_file = os.path.join(paddle_model_dir, "model.pdmodel")
     params_file = os.path.join(paddle_model_dir, "model.pdiparams")
 

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -49,6 +49,7 @@ def export(model_file,
 
 
 def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
+    import paddle
     from paddle2onnx.utils import logging, paddle_jit_save_configs
     # Get PaddleInference model file path
     dirname = os.path.split(save_file)[0]

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -74,7 +74,7 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
         params_file = ""
 
     if save_file is None:
-        return paddle2onnx.export(model_file, params_file, save_file, opset_version)
+        return export(model_file, params_file, save_file, opset_version)
     else:
-        paddle2onnx.export(model_file, params_file, save_file, opset_version)
+        export(model_file, params_file, save_file, opset_version)
     logging.info("ONNX model saved in {}.".format(save_file))

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -20,7 +20,7 @@ from paddle2onnx.utils import logging, paddle_jit_save_configs
 def export(model_file,
            params_file="",
            save_file=None,
-           opset_version=11,
+           opset_version=9,
            auto_upgrade_opset=True,
            verbose=True,
            enable_onnx_checker=True,
@@ -50,7 +50,7 @@ def export(model_file,
         return onnx_model_str
 
 
-def dygraph2onnx(layer, save_file, input_spec=None, opset_version=11, **configs):
+def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
     # Get PaddleInference model file path
     dirname = os.path.split(save_file)[0]
     paddle_model_dir = os.path.join(dirname, "paddle_model_temp_dir")

--- a/tests/test_dygraph2onnx.py
+++ b/tests/test_dygraph2onnx.py
@@ -15,7 +15,7 @@ class TestDygraph2OnnxAPI(unittest.TestCase):
     def test_api(self):
         net = SimpleNet()
         input_spec = [paddle.static.InputSpec(shape=[None, 10], dtype='float32')]
-        paddle2onnx.convert.dygraph2onnx(net, "simple_net.onnx", input_spec)
+        paddle2onnx.dygraph2onnx(net, "simple_net.onnx", input_spec)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_dygraph2onnx.py
+++ b/tests/test_dygraph2onnx.py
@@ -1,0 +1,21 @@
+import paddle
+import unittest
+import paddle2onnx
+
+class SimpleNet(paddle.nn.Layer):
+    def __init__(self, num_classes=1000):
+        super().__init__()
+        self.fc = paddle.nn.Linear(10, 10)
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+class TestDygraph2OnnxAPI(unittest.TestCase):
+    def test_api(self):
+        net = SimpleNet()
+        input_spec = [paddle.static.InputSpec(shape=[None, 10], dtype='float32')]
+        paddle2onnx.convert.dygraph2onnx(net, "simple_net.onnx", input_spec)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 1. Background

在飞桨Paddle主仓库里，内涵了一个paddle.onnx子模块，并提供了[paddle.onnx.export](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/onnx/export_cn.html#export) API 支持直接对用户的动态图Layer进行导出，其内在是调用 `paddle2onnx.convert.dygraph2onnx` 

但在某个版本之后，paddle2onnx在`__init__.py` 里屏蔽了 `convert.py` 子module里的接口，仅保留了export接口（也合理）。但为了保持兼容性，故此PR进行了适配

## 2. What's New

+ 由于1.2.4下的paddle2onnx不再保留 legacy 目录，故统一移除 `export_onnx` 和 `program2onnx` 两个旧API
+ 将 `__int__.py` 里的 export API 移动到 `convert.py` 里，保持`__init__.py` 仅做 index 子模块 import语句管理
+ 保留了`dygraph2onnx` API 以兼容适配飞桨主仓库的`paddle.onnx.export` 用法

关联issue: https://github.com/PaddlePaddle/Paddle2ONNX/issues/1302