### PR TITLE
[setuptools]Ignore all *.h/*.cc et.al unrelated files packed into wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ version = {file = "VERSION_NUMBER"}
 [tool.setuptools.packages.find]
 include = ["paddle2onnx*"]
 
+[tool.setuptools.exclude-package-data]
+"*" = ["*.h", "*.cc", "*.bak"]
+
 [tool.setuptools_scm]
 write_to = "paddle2onnx/version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ version = {file = "VERSION_NUMBER"}
 include = ["paddle2onnx*"]
 
 [tool.setuptools.exclude-package-data]
-"*" = ["*.h", "*.cc", "*.bak"]
+"*" = ["*.h", "*.cc", "*.bak", "*.in"]
 
 [tool.setuptools_scm]
 write_to = "paddle2onnx/version.py"


### PR DESCRIPTION
## What's New ?

在 `pyproject.toml` 添加对C++ 源码文件的忽略标记，避免其被打包进wheel 文件里。

**优化前的`wheel` 内目录文件：**
<img width="696" alt="image" src="https://github.com/user-attachments/assets/804cc306-b243-43e2-9b65-cf70947d0d04">


**优化后的`wheel` 内目录文件：**
<img width="706" alt="image" src="https://github.com/user-attachments/assets/f9104085-e6cc-4463-93b6-268dbeeeebd8">

