### PR TITLE
[PIR] Completion of unit testing in PIR mode

### DIFF
--- a/paddle2onnx/mapper/activation/activation.h
+++ b/paddle2onnx/mapper/activation/activation.h
@@ -47,8 +47,33 @@ class ActivationMapper : public Mapper {
     op_mapper_["reciprocal"] = "Reciprocal";
   }
 
+  ActivationMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i)
+      : Mapper(p, helper, i) {
+    in_pir_mode = true;
+    op_mapper_["relu"] = "Relu";
+    op_mapper_["tanh"] = "Tanh";
+    op_mapper_["log"] = "Log";
+    op_mapper_["sqrt"] = "Sqrt";
+    op_mapper_["softplus"] = "Softplus";
+    op_mapper_["exp"] = "Exp";
+    op_mapper_["floor"] = "Floor";
+    op_mapper_["cos"] = "Cos";
+    op_mapper_["sin"] = "Sin";
+    op_mapper_["round"] = "Round";
+    op_mapper_["abs"] = "Abs";
+    op_mapper_["acos"] = "Acos";
+    op_mapper_["asin"] = "Asin";
+    op_mapper_["atan"] = "Atan";
+    op_mapper_["tan"] = "Tan";
+    op_mapper_["ceil"] = "Ceil";
+    op_mapper_["erf"] = "Erf";
+    op_mapper_["softsign"] = "Softsign";
+    op_mapper_["reciprocal"] = "Reciprocal";
+  }
+
   int32_t GetMinOpsetVersion(bool verbose) override;
   void Opset7() override;
+  void SetOpInputOutputIndex() override;
 
  private:
   std::map<std::string, std::string> op_mapper_;

--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -36,7 +36,7 @@
 inline std::string convert_pir_op_name(const std::string pir_op_name) {
     std::unordered_map<std::string, std::string> op_name_mappings = {
         {"matmul", "matmul_v2"},
-        {"relu", "relu6"},
+        // {"relu", "relu6"},
         {"batch_norm_", "batch_norm"},
         {"flatten", "flatten_contiguous_range"},
         {"add", "elementwise_add"}};

--- a/paddle2onnx/mapper/nn/batch_norm.cc
+++ b/paddle2onnx/mapper/nn/batch_norm.cc
@@ -25,10 +25,10 @@ void BatchNormMapper::SetOpInputOutputIndex()
 {
   input_idx_ = {
     {"X", 0},
-    {"Scale", 1}, 
-    {"Bias", 2},
-    {"Mean", 3},
-    {"Variance", 4},
+    {"Mean", 1},
+    {"Variance", 2},
+    {"Scale", 3}, 
+    {"Bias", 4},
   };
   output_idx_ = {{"Y", 0}};
 }

--- a/paddle2onnx/mapper/nn/conv2d.cc
+++ b/paddle2onnx/mapper/nn/conv2d.cc
@@ -21,6 +21,7 @@ namespace paddle2onnx {
 REGISTER_MAPPER(conv2d, Conv2dMapper)
 REGISTER_MAPPER(depthwise_conv2d, Conv2dMapper)
 REGISTER_PIR_MAPPER(conv2d, Conv2dMapper)
+REGISTER_PIR_MAPPER(depthwise_conv2d, Conv2dMapper)
 
 int32_t Conv2dMapper::GetMinOpsetVersion(bool verbose) {
   // NHWC is not supported

--- a/paddle2onnx/mapper/tensor/reshape2.cc
+++ b/paddle2onnx/mapper/tensor/reshape2.cc
@@ -20,8 +20,20 @@
 
 namespace paddle2onnx {
 REGISTER_MAPPER(reshape2, Reshape2Mapper)
+REGISTER_PIR_MAPPER(reshape, Reshape2Mapper)
 
+void Reshape2Mapper::SetOpInputOutputIndex() {
+  input_idx_ = {
+    {"X", 0},
+    {"Shape", 1},
+    {"ShapeTensor", 1},
+  };
+  output_idx_ = {
+    {"Out", 0},
+  };
+}
 void Reshape2Mapper::Opset7() {
+  SetOpInputOutputIndex();
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
 

--- a/paddle2onnx/mapper/tensor/reshape2.h
+++ b/paddle2onnx/mapper/tensor/reshape2.h
@@ -26,7 +26,13 @@ class Reshape2Mapper : public Mapper {
                  int64_t op_id)
       : Mapper(p, helper, block_id, op_id) {}
 
+  Reshape2Mapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i)
+      : Mapper(p, helper, i) {
+      in_pir_mode = true;
+  }
+
   void Opset7() override;
+  void SetOpInputOutputIndex() override;
 };
 
 }  // namespace paddle2onnx

--- a/tests/auto_scan_test.py
+++ b/tests/auto_scan_test.py
@@ -25,6 +25,7 @@ from onnxbase import APIOnnx, randtool
 from itertools import product
 import copy
 from inspect import isfunction
+from onnxbase import _test_with_pir
 
 paddle.set_device("cpu")
 
@@ -73,6 +74,7 @@ class OPConvertAutoScanTest(unittest.TestCase):
         paddle.enable_static()
         self.num_ran_models = 0
 
+    # @_test_with_pir
     def run_and_statis(self,
                        max_examples=100,
                        opset_version=[7, 9, 15],

--- a/tests/auto_scan_test.py
+++ b/tests/auto_scan_test.py
@@ -81,6 +81,7 @@ class OPConvertAutoScanTest(unittest.TestCase):
                        reproduce=None,
                        min_success_num=25,
                        max_duration=-1):
+        self.num_ran_models = 0
         if os.getenv("CE_STAGE", "OFF") == "ON":
             max_examples *= 10
             min_success_num *= 10

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -147,14 +147,23 @@ class BuildClass(paddle.nn.Layer):
 
 
 dtype_map = {
-    paddle.float32: np.float32,
-    paddle.float16: np.float16,
-    paddle.float64: np.float64,
-    paddle.int64: np.int64,
-    paddle.int32: np.int32,
-    paddle.int16: np.int16,
-    paddle.int8: np.int8,
-    paddle.bool: np.bool_,
+    paddle.base.core.VarDesc.VarType.FP32: np.float32,
+    paddle.base.core.VarDesc.VarType.FP16: np.float16,
+    paddle.base.core.VarDesc.VarType.FP64: np.float64,
+    paddle.base.core.VarDesc.VarType.INT64: np.int64,
+    paddle.base.core.VarDesc.VarType.INT32: np.int32,
+    paddle.base.core.VarDesc.VarType.INT16: np.int16,
+    paddle.base.core.VarDesc.VarType.INT8: np.int8,
+    paddle.base.core.VarDesc.VarType.BOOL: np.bool_,
+
+    paddle.base.core.DataType.FLOAT32: np.float32,
+    paddle.base.core.DataType.FLOAT16: np.float16,
+    paddle.base.core.DataType.FLOAT64: np.float64,
+    paddle.base.core.DataType.INT64: np.int64,
+    paddle.base.core.DataType.INT32: np.int32,
+    paddle.base.core.DataType.INT16: np.int16,
+    paddle.base.core.DataType.INT8: np.int8,
+    paddle.base.core.DataType.BOOL: np.bool_,
 }
 
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_add_9():
     """
     api: paddle.add
@@ -49,6 +51,7 @@ def test_add_9():
     obj.run()
 
 
+@_test_with_pir
 def test_add_10():
     """
     api: paddle.add
@@ -65,6 +68,7 @@ def test_add_10():
     obj.run()
 
 
+@_test_with_pir
 def test_add_11():
     """
     api: paddle.add
@@ -81,6 +85,7 @@ def test_add_11():
     obj.run()
 
 
+@_test_with_pir
 def test_add_12():
     """
     api: paddle.add

--- a/tests/test_auto_scan_batch_norm.py
+++ b/tests/test_auto_scan_batch_norm.py
@@ -19,6 +19,7 @@ import numpy as np
 import unittest
 import paddle
 from paddle import ParamAttr
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -124,6 +125,7 @@ class TestBatchNormConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_conv2d.py
+++ b/tests/test_auto_scan_conv2d.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -157,6 +158,7 @@ class TestConv2dConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_flatten.py
+++ b/tests/test_auto_scan_flatten.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -85,6 +86,7 @@ class TestFlattenConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_matmul.py
+++ b/tests/test_auto_scan_matmul.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -68,6 +69,7 @@ class TestMatmulConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_thresholded_relu.py
+++ b/tests/test_auto_scan_thresholded_relu.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):

--- a/tests/test_avg_pool2d.py
+++ b/tests/test_avg_pool2d.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_avg_pool2d_9():
     """
     api: paddle.nn.functional.avg_pool2d
@@ -49,6 +51,7 @@ def test_avg_pool2d_9():
     obj.run()
 
 
+@_test_with_pir
 def test_avg_pool2d_10():
     """
     api: paddle.nn.functional.avg_pool2d
@@ -64,7 +67,7 @@ def test_avg_pool2d_10():
             randtool("float", -1, 1, [3, 1, 10, 10]).astype('float32')))
     obj.run()
 
-
+@_test_with_pir
 def test_avg_pool2d_11():
     """
     api: paddle.nn.functional.avg_pool2d
@@ -80,7 +83,7 @@ def test_avg_pool2d_11():
             randtool("float", -1, 1, [3, 1, 10, 10]).astype('float32')))
     obj.run()
 
-
+@_test_with_pir
 def test_avg_pool2d_12():
     """
     api: paddle.nn.functional.avg_pool2d

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_flatten_9():
     """
     api: paddle.flatten
@@ -49,6 +51,7 @@ def test_flatten_9():
     obj.run()
 
 
+@_test_with_pir
 def test_flatten_10():
     """
     api: paddle.flatten
@@ -65,6 +68,7 @@ def test_flatten_10():
     obj.run()
 
 
+@_test_with_pir
 def test_flatten_11():
     """
     api: paddle.flatten
@@ -81,6 +85,7 @@ def test_flatten_11():
     obj.run()
 
 
+@_test_with_pir
 def test_flatten_12():
     """
     api: paddle.flatten

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_matmul_9():
     """
     api: paddle.matmul
@@ -49,6 +51,7 @@ def test_matmul_9():
     obj.run()
 
 
+@_test_with_pir
 def test_matmul_10():
     """
     api: paddle.matmul
@@ -65,6 +68,7 @@ def test_matmul_10():
     obj.run()
 
 
+@_test_with_pir
 def test_matmul_11():
     """
     api: paddle.matmul
@@ -81,6 +85,7 @@ def test_matmul_11():
     obj.run()
 
 
+@_test_with_pir
 def test_matmul_12():
     """
     api: paddle.matmul

--- a/tests/test_nn_AdaptiveAvgPool2D.py
+++ b/tests/test_nn_AdaptiveAvgPool2D.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -34,6 +35,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_AdaptiveAvgPool2D_base():
     """
     api: paddle.nn.AdaptiveAvgPool2D

--- a/tests/test_nn_Conv2D.py
+++ b/tests/test_nn_Conv2D.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -55,6 +56,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_Conv2D_9():
     """
     api: paddle.Conv2D
@@ -69,8 +71,10 @@ def test_Conv2D_9():
         paddle.to_tensor(
             randtool("float", -1, 1, [3, 1, 10, 10]).astype('float32')))
     obj.run()
+    print("finish")
 
 
+@_test_with_pir
 def test_Conv2D_10():
     """
     api: paddle.nn.Conv2D
@@ -87,6 +91,7 @@ def test_Conv2D_10():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_11():
     """
     api: paddle.nn.Conv2D
@@ -103,6 +108,7 @@ def test_Conv2D_11():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_12():
     """
     api: paddle.nn.Conv2D
@@ -119,6 +125,7 @@ def test_Conv2D_12():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_padding_0_9():
     """
     api: paddle.nn.Conv2D
@@ -135,6 +142,7 @@ def test_Conv2D_padding_0_9():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_padding_1_9():
     """
     api: paddle.nn.Conv3D
@@ -151,6 +159,7 @@ def test_Conv2D_padding_1_9():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_padding_2_9():
     """
     api: paddle.nn.Conv2D
@@ -167,6 +176,7 @@ def test_Conv2D_padding_2_9():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_groups_1_9():
     """
     api: paddle.nn.Conv2D
@@ -183,6 +193,7 @@ def test_Conv2D_groups_1_9():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_groups_2_9():
     """
     api: paddle.nn.Conv2D
@@ -199,6 +210,7 @@ def test_Conv2D_groups_2_9():
     obj.run()
 
 
+@_test_with_pir
 def test_Conv2D_dilation_2_9():
     """
     api: paddle.nn.Conv2D

--- a/tests/test_nn_MaxPool2D.py
+++ b/tests/test_nn_MaxPool2D.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -48,6 +49,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_MaxPool2D_base():
     """
     api: paddle.MaxPool2D
@@ -64,6 +66,7 @@ def test_MaxPool2D_base():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_VALID():
     """
     api: paddle.MaxPool2D
@@ -80,6 +83,7 @@ def test_MaxPool2D_base_VALID():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_SAME():
     """
     api: paddle.MaxPool2D
@@ -96,6 +100,7 @@ def test_MaxPool2D_base_SAME():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_Padding_0():
     """
     api: paddle.MaxPool2D
@@ -112,6 +117,7 @@ def test_MaxPool2D_base_Padding_0():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_Padding_1():
     """
     api: paddle.MaxPool2D
@@ -128,6 +134,7 @@ def test_MaxPool2D_base_Padding_1():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_Padding_2():
     """
     api: paddle.MaxPool2D
@@ -144,6 +151,7 @@ def test_MaxPool2D_base_Padding_2():
     obj.run()
 
 
+@_test_with_pir
 def test_MaxPool2D_base_Padding_3():
     """
     api: paddle.MaxPool2D

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_relu_9():
     """
     api: paddle.relu
@@ -49,6 +51,7 @@ def test_relu_9():
     obj.run()
 
 
+@_test_with_pir
 def test_relu_10():
     """
     api: paddle.relu
@@ -65,6 +68,7 @@ def test_relu_10():
     obj.run()
 
 
+@_test_with_pir
 def test_relu_11():
     """
     api: paddle.relu
@@ -81,6 +85,7 @@ def test_relu_11():
     obj.run()
 
 
+@_test_with_pir
 def test_relu_12():
     """
     api: paddle.relu

--- a/tests/test_relu6.py
+++ b/tests/test_relu6.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_relu6_9():
     """
     api: paddle.relu6
@@ -49,6 +51,7 @@ def test_relu6_9():
     obj.run()
 
 
+@_test_with_pir
 def test_relu6_10():
     """
     api: paddle.relu6
@@ -65,6 +68,7 @@ def test_relu6_10():
     obj.run()
 
 
+@_test_with_pir
 def test_relu6_11():
     """
     api: paddle.relu6
@@ -81,6 +85,7 @@ def test_relu6_11():
     obj.run()
 
 
+@_test_with_pir
 def test_relu6_12():
     """
     api: paddle.relu6


### PR DESCRIPTION
Add decorator `_test_with_pir` to test the operator conversion results in PIR
Currently supported unit test files include：
* test_auto_scan_conv2d.py
* test_avg_pool2d.py
* test_nn_AdaptiveAvgPool2D.py
* test_nn_Conv2D.py
* test_nn_MaxPool2D.py