### PR TITLE
[PIR] Adjust some interfaces in PIR && Support conversion of builtin.combine and  builtin.split 

### DIFF
--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -42,10 +42,16 @@ inline std::string convert_pir_op_name(const std::string pir_op_name) {
         {"add", "elementwise_add"}};
   std::string op_name = pir_op_name;
   std::string prefix = "pd_op.";
+  std::string builtin_prefix = "builtin.";
 
   size_t prefix_pos = op_name.find(prefix);
   if (prefix_pos != std::string::npos) {
     op_name = op_name.substr(prefix_pos + prefix.size());
+  }
+  else {
+    if(op_name.substr(0, builtin_prefix.size()) == builtin_prefix) {
+        op_name[builtin_prefix.size() - 1] = '_';
+    }
   }
   auto it = op_name_mappings.find(op_name);
   if (it != op_name_mappings.end()) {

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -56,12 +56,20 @@ class Mapper {
     if (opset_version <= helper_->GetOpsetVersion()) {
       v = false;
     }
-    auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
     std::string output_name = "";
-    if (op.outputs(0).arguments_size() > 0) {
-      output_name = op.outputs(0).arguments(0);
+    std::string op_type = "";
+    if(in_pir_mode) {
+      auto &op = pir_parser_-> global_blocks_ops[pir_op_idx_];
+      output_name = GetOutput(0)[0].name;
+      op_type = op->name();
     }
-    std::string op_type = op.type();
+    else {
+      auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
+      if (op.outputs(0).arguments_size() > 0) {
+        output_name = op.outputs(0).arguments(0);
+      }
+      op_type = op.type();
+    }
     std::string prefix = "[Paddle2ONNX] [" + op_type + ": " + output_name + "]";
     return P2OLogger(v, prefix);
   }
@@ -183,15 +191,13 @@ class Mapper {
 
   bool HasInput(const std::string &name) const {
     if (in_pir_mode) {
-      int32_t value_idx = pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, name, true);
-      return pir_parser_->OpHasInput(pir_op_idx_, value_idx);
+      return pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, name, true) != -1;
     }
     return parser_->OpHasInput(block_idx_, op_idx_, name);
   }
   bool HasOutput(const std::string &name) const {
     if (in_pir_mode) {
-      int32_t value_idx = pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, name, false);
-      return pir_parser_->OpHasOutput(pir_op_idx_, value_idx);
+      return pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, name, false) != -1;
     }
     return parser_->OpHasOutput(block_idx_, op_idx_, name);
   }
@@ -231,10 +237,13 @@ class Mapper {
     return parser_->GetOpAttrVar(block_idx_, op_idx_, name);
   }
 
+  /*
+   * todo(wangmingkai02): add GetInputAttrVar function.
   std::vector<int64_t> GetInputAttrVar(const std::string &input_name, const std::string &attr_name) const {
     int32_t value_idx = pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, input_name, true);
     return pir_parser_->GetOpAttrVar(pir_op_idx_, value_idx, attr_name);
   }
+  */
   
 
   bool HasAttr(const std::string &name) const {
@@ -250,7 +259,7 @@ class Mapper {
   void GetAttr(const std::string &name, int64_t *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -259,7 +268,7 @@ class Mapper {
   void GetAttr(const std::string &name, float *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -268,7 +277,7 @@ class Mapper {
   void GetAttr(const std::string &name, double *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -277,7 +286,7 @@ class Mapper {
   void GetAttr(const std::string &name, bool *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -286,7 +295,7 @@ class Mapper {
   void GetAttr(const std::string &name, std::string *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -295,7 +304,7 @@ class Mapper {
   void GetAttr(const std::string &name, std::vector<int64_t> *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -304,7 +313,7 @@ class Mapper {
   void GetAttr(const std::string &name, std::vector<float> *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -313,7 +322,7 @@ class Mapper {
   void GetAttr(const std::string &name, std::vector<double> *val) {
     if (in_pir_mode) {
       auto &op = pir_parser_->global_blocks_ops[pir_op_idx_];
-      pir_parser_->GetOpAttr(op, name, val);
+      pir_parser_->GetOpAttr(op, pir_parser_->GetOpArgName(pir_op_idx_, name), val);
     } else {
       auto &op = parser_->GetOpDesc(block_idx_, op_idx_);
       parser_->GetOpAttr(op, name, val);
@@ -321,8 +330,14 @@ class Mapper {
   }
 
   bool IsConstantInput(const std::string &input_key) const {
-    auto input_info = GetInput(input_key);
-    return parser_->IsConstantTensor(block_idx_, input_info[0].name);
+    if(in_pir_mode) {
+      int32_t value_idx = pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, input_key, true);
+      return pir_parser_->IsConstantTensor(pir_op_idx_, value_idx);
+    }
+    else {
+      auto input_info = GetInput(input_key);
+      return parser_->IsConstantTensor(block_idx_, input_info[0].name);
+    }
   }
 
   bool IsConstant(const TensorInfo &info) const {
@@ -331,8 +346,23 @@ class Mapper {
 
   template <typename T>
   bool TryGetInputValue(const std::string &input_key, std::vector<T> *data) {
-    auto input_info = GetInput(input_key);
-    return parser_->TryGetTensorValue(block_idx_, input_info[0].name, data);
+    if(in_pir_mode) {
+      return pir_parser_->TryGetTensorValue(pir_op_idx_, pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, input_key, true), data);
+    }
+    else {
+      auto input_info = GetInput(input_key);
+      return parser_->TryGetTensorValue(block_idx_, input_info[0].name, data);
+    }
+  }
+
+  template <typename T>
+  bool TryGetInputValue(const std::string &input_key, T *data) {
+    if(in_pir_mode) {
+      return pir_parser_->TryGetTensorValue(pir_op_idx_, pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, input_key, true), data);
+    }
+    else {
+      Assert(false, "Not support in old IR.");
+    }
   }
 
   template <typename T>

--- a/paddle2onnx/mapper/mapper.h
+++ b/paddle2onnx/mapper/mapper.h
@@ -201,7 +201,7 @@ class Mapper {
       return pir_parser_->GetOpInput(pir_op_idx_, value_idx);
     }
     return parser_->GetOpInput(block_idx_, op_idx_, name);
-  }
+  } 
   std::vector<TensorInfo> GetOutput(const std::string &name) const {
     if (in_pir_mode) {
       int32_t value_idx = pir_parser_->GetOpInputOutputName2Idx(pir_op_idx_, name, false);
@@ -209,6 +209,17 @@ class Mapper {
     }
     return parser_->GetOpOutput(block_idx_, op_idx_, name);
   }
+
+  std::vector<TensorInfo> GetInput(int64_t input_idx) const {
+    Assert(in_pir_mode, "Only support PIR mode");
+    return pir_parser_->GetOpInput(pir_op_idx_, input_idx);
+  }
+
+  std::vector<TensorInfo> GetOutput(int64_t input_idx) const {
+    Assert(in_pir_mode, "Only support PIR mode");
+    return pir_parser_->GetOpOutput(pir_op_idx_, input_idx);
+  }
+
   // Judge whether Attribute(name)'s type is Var or Vars.
   bool IsAttrVar(const std::string &name) const {
     if (in_pir_mode) return pir_parser_->OpIsAttrVar(pir_op_idx_, name);

--- a/paddle2onnx/mapper/nn/pool2d.cc
+++ b/paddle2onnx/mapper/nn/pool2d.cc
@@ -280,8 +280,8 @@ void Pool2dMapper::Opset7() {
       k_size_.push_back(ksize.shape[i]);
     }
     */
-   k_size_ = GetInputAttrVar("ksize", "value");
-    
+    // k_size_ = GetInputAttrVar("ksize", "value");
+    TryGetInputValue("ksize", &k_size_);
   } else{
     GetAttr("ksize", &k_size_);
   }

--- a/paddle2onnx/mapper/tensor/builtin_combine.cc
+++ b/paddle2onnx/mapper/tensor/builtin_combine.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle2onnx/mapper/tensor/builtin_combine.h"
+#include "paddle/common/enforce.h"
+#include "paddle/pir/include/core/builtin_op.h"
+#include "paddle/pir/include/core/operation.h"
+
+namespace paddle2onnx {
+REGISTER_PIR_MAPPER(builtin_combine, BuiltinCombineMapper)
+
+int64_t BuiltinCombineMapper::GetInputNum() {
+    auto& op = pir_parser_->global_blocks_ops[pir_op_idx_];
+    PADDLE_ENFORCE_EQ(
+          op->isa<pir::CombineOp>(),
+          true,
+          common::errors::InvalidArgument(
+            "The operator type must be builtin.combine, but the actual operator type is %s.",
+            op->name()));
+    return op->dyn_cast<pir::CombineOp>().inputs().size();
+}
+
+void BuiltinCombineMapper::Opset7() {
+    auto output_info = GetOutput(0);
+    int64_t input_num = GetInputNum();
+    PADDLE_ENFORCE_EQ(
+        input_num == output_info.size(),
+        true,
+        common::errors::InvalidArgument(
+            "The number of inputs and outputs must be the same, but the actual "
+            "input number is %d and output number is %d.",
+            input_num, output_info.size()));
+    for(int64_t i = 0; i < input_num; ++i) {
+        auto input_info = GetInput(i);
+        helper_->MakeNode("Identity", {input_info[0].name}, {output_info[i].name});
+    }
+}
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/builtin_combine.h
+++ b/paddle2onnx/mapper/tensor/builtin_combine.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+
+#include "paddle2onnx/mapper/mapper.h"
+
+namespace paddle2onnx {
+
+// PIR builtin.combine operation
+class BuiltinCombineMapper : public Mapper {
+ public:
+  BuiltinCombineMapper(const PaddlePirParser& p, OnnxHelper* helper, 
+                 int64_t op_id)
+      : Mapper(p, helper, op_id) {
+    in_pir_mode = true;
+  }
+
+  void Opset7() override;
+ private:
+    int64_t GetInputNum();
+};
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/builtin_split.cc
+++ b/paddle2onnx/mapper/tensor/builtin_split.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle2onnx/mapper/tensor/builtin_split.h"
+
+namespace paddle2onnx {
+REGISTER_PIR_MAPPER(builtin_split, BuiltinSplitMapper)
+
+int64_t BuiltinSplitMapper::GetOutputNum() {
+    auto& op = pir_parser_->global_blocks_ops[pir_op_idx_];
+    PADDLE_ENFORCE_EQ(
+          op->isa<pir::SplitOp>(),
+          true,
+          common::errors::InvalidArgument(
+            "The operator type must be builtin.split, but the actual operator type is %s.",
+            op->name()));
+    return op->dyn_cast<pir::SplitOp>().outputs().size();
+}
+
+void BuiltinSplitMapper::Opset7() {
+    auto input_info = GetInput(0);
+    int64_t output_num = GetOutputNum();
+    PADDLE_ENFORCE_EQ(
+        output_num == input_info.size(),
+        true,
+        common::errors::InvalidArgument(
+            "The number of inputs and outputs must be the same, but the actual "
+            "input number is %d and output number is %d.",
+            input_info.size(), output_num));
+    for(int64_t i = 0; i < output_num; ++i) {
+        auto output_info = GetOutput(i);
+        helper_->MakeNode("Identity", {input_info[i].name}, {output_info[0].name});
+    } 
+}
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/builtin_split.h
+++ b/paddle2onnx/mapper/tensor/builtin_split.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+
+#include "paddle2onnx/mapper/mapper.h"
+
+namespace paddle2onnx {
+
+// PIR builtin.split operation
+class BuiltinSplitMapper : public Mapper {
+ public:
+  BuiltinSplitMapper(const PaddlePirParser& p, OnnxHelper* helper, 
+                 int64_t op_id)
+      : Mapper(p, helper, op_id) {
+    in_pir_mode = true;
+  }
+
+  void Opset7() override;
+ private:
+  int64_t GetOutputNum();
+};
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -184,7 +184,7 @@ namespace paddle2onnx {
       }
     }
   }
-  
+
   int32_t PaddlePirParser::GetOpInputOutputName2Idx(int64_t op_id, std::string name, bool is_input) const {
       auto& op = global_blocks_ops[op_id];
       pir::IrContext* ctx = pir::IrContext::Instance();
@@ -194,6 +194,10 @@ namespace paddle2onnx {
                     .at("op_name")
                     .dyn_cast<pir::StrAttribute>()
                     .AsString();
+      }
+      std::string builtin_prefix = "builtin.";
+      if(op_name.substr(0, builtin_prefix.size()) == builtin_prefix) {
+          Assert(false, "builtin op " + op_name + " is not supported by GetOpInputOutputName2Idx.");
       }
       if(_op_arg_name_mappings.count(op_name)) {
         name = _op_arg_name_mappings.at(op_name).count(name) ? _op_arg_name_mappings.at(op_name).at(name) : name;

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -36,7 +36,8 @@ class PaddlePirParser {
   // int NumOfOps(int block_idx) const;
   int NumOfProgramOps() const;
   // recoring set of operators for pir global block
-  TensorInfo GetTensorInfo(std::string name, const pir::Operation *op);
+  TensorInfo GetTensorInfo(const std::string& name, const pir::Type& value_type) const;
+  std::vector<TensorInfo> GetTensorInfo(const pir::Value& value) const;
   bool OpIsAttrVar(int64_t op_id,
                    const std::string &name) const;
   bool OpHasInput(int64_t op_id,
@@ -86,7 +87,7 @@ class PaddlePirParser {
   void GetAllOpOutputName();
   std::string GenOpInputOutputName(const std::string& name) const;
   void AddOpOutputName(pir::Operation *op, std::string var_name, int64_t output_idx) const;
-  std::string GetOpOutputName(const pir::OpOperand& operand) const;
+  std::string GetOpOutputName(const pir::Value& source) const;
   void GetOpArgNameMappings();
   std::vector<std::map<std::string, int64_t>> _constant_ops;
   mutable std::unordered_map<std::string, int64_t> _name_counter;


### PR DESCRIPTION
* Adjust `GetTensorInfo`, `GetOpInput`, `GetOpOutput` in PIR parser to support multi tensors within a var
* Support builtin.combine and builtin.split mapper
* Add `GetOpArgName`, `TryGetTensorValue`, `IsConstantTensor` in PIR parser
* Adjust the return value of `GetOpInputOutputName2Idx`, `-1` indicates that the variable does not exist
* Adjust `TryGetInputValue`, `GetAttr`, `HasInput`, `HasOutput`, `IsConstantInput` in `mapper.h`