### PR TITLE
【P2O-PIR】Support op concat, split, split_with_num, transpose

### DIFF
--- a/paddle2onnx/mapper/tensor/assign_value.cc
+++ b/paddle2onnx/mapper/tensor/assign_value.cc
@@ -20,6 +20,7 @@
 
 namespace paddle2onnx {
 REGISTER_MAPPER(assign_value, AssignValueMapper)
+REGISTER_PIR_MAPPER(assign_value_, AssignValueMapper)
 
 int32_t AssignValueMapper::GetMinOpsetVersion(bool verbose) {
   int32_t dtype = static_cast<int32_t>(dtype_);
@@ -34,15 +35,15 @@ int32_t AssignValueMapper::GetMinOpsetVersion(bool verbose) {
 void AssignValueMapper::Opset7() {
   auto output_info = GetOutput("Out");
   int32_t dtype = static_cast<int32_t>(dtype_);
-  if (dtype == P2ODataType::INT32) {
+  if (int64_values_.size() > 0) {
     helper_->Assign(output_info[0].name, GetOnnxDtype(output_info[0].dtype),
                     shape_, int64_values_);
-  } else if (dtype == P2ODataType::FP32) {
+  } else if (fp32_values_.size() > 0) {
     helper_->Assign(output_info[0].name, GetOnnxDtype(output_info[0].dtype),
                     shape_, fp32_values_);
-  } else if (dtype == P2ODataType::INT64) {
+  } else if (fp64_values_.size() > 0) {
     helper_->Assign(output_info[0].name, GetOnnxDtype(output_info[0].dtype),
-                    shape_, int64_values_);
+                    shape_, fp64_values_);
   }
 }
 

--- a/paddle2onnx/mapper/tensor/concat.h
+++ b/paddle2onnx/mapper/tensor/concat.h
@@ -27,6 +27,11 @@ class ConcatMapper : public Mapper {
       : Mapper(p, helper, block_id, op_id) {
     GetAttr("axis", &axis_);
   }
+  ConcatMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i)
+      : Mapper(p, helper, i) {
+    in_pir_mode = true;
+    // GetAttr("axis", &axis_); axis serves as input in PIR
+  }
   int32_t GetMinOpsetVersion(bool verbose) override;
   void Opset7() override;
 

--- a/paddle2onnx/mapper/tensor/split.h
+++ b/paddle2onnx/mapper/tensor/split.h
@@ -30,6 +30,14 @@ class SplitMapper : public Mapper {
     GetAttr("num", &num_);
   }
 
+  SplitMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i)
+      : Mapper(p, helper, i) {
+      in_pir_mode = true;
+    // GetAttr("axis", &axis_);
+    // GetAttr("sections", &sections_);
+    // GetAttr("num", &num_);
+  }
+
   int32_t GetMinOpsetVersion(bool verbose) override;
   void Opset7() override;
   void Opset13() override;

--- a/paddle2onnx/mapper/tensor/transpose2.cc
+++ b/paddle2onnx/mapper/tensor/transpose2.cc
@@ -19,6 +19,7 @@
 
 namespace paddle2onnx {
 REGISTER_MAPPER(transpose2, Transpose2Mapper)
+REGISTER_PIR_MAPPER(transpose, Transpose2Mapper)
 
 void Transpose2Mapper::Opset7() {
   auto input_info = GetInput("X");

--- a/paddle2onnx/mapper/tensor/transpose2.h
+++ b/paddle2onnx/mapper/tensor/transpose2.h
@@ -25,6 +25,10 @@ class Transpose2Mapper : public Mapper {
   Transpose2Mapper(const PaddleParser& p, OnnxHelper* helper, int64_t block_id,
                    int64_t op_id)
       : Mapper(p, helper, block_id, op_id) {}
+  Transpose2Mapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i)
+      : Mapper(p, helper, i) {
+        in_pir_mode = true;
+      }
   void Opset7() override;
 
  private:

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -525,9 +525,9 @@ void PaddlePirParser::GetOpAttr(const pir::Operation* op,
       found = true;
       if (pair.second.isa<pir::Int32Attribute>()) {
         *res = pair.second.dyn_cast<::pir::Int32Attribute>().data();
-      } else {
+      } else if (pair.second.isa<pir::Int64Attribute>()) {
         *res = pair.second.dyn_cast<::pir::Int64Attribute>().data();
-      }
+      } 
       break;
     }
   }

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -35,6 +35,14 @@ def _test_with_pir(func):
     return wrapper
 
 
+def _test_only_pir(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with paddle.pir_utils.DygraphPirGuard():
+            func(*args, **kwargs)
+    return wrapper
+
+
 def compare_data(result_data, expect_data, delta, rtol):
     res_data = np.allclose(result_data, expect_data, atol=delta, rtol=rtol, equal_nan=True)
     if res_data is True:

--- a/tests/test_auto_scan_concat.py
+++ b/tests/test_auto_scan_concat.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):

--- a/tests/test_auto_scan_split.py
+++ b/tests/test_auto_scan_split.py
@@ -19,6 +19,7 @@ import numpy as np
 import unittest
 import paddle
 import random
+from onnxbase import _test_only_pir
 
 
 class Net(BaseNet):
@@ -93,6 +94,7 @@ class TestSplitConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_only_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_transpose.py
+++ b/tests/test_auto_scan_transpose.py
@@ -18,6 +18,7 @@ import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -68,6 +69,7 @@ class TestTransposeConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_concat_9():
     """
     api: paddle.concat
@@ -49,6 +51,7 @@ def test_concat_9():
     obj.run()
 
 
+@_test_with_pir
 def test_concat_10():
     """
     api: paddle.concat
@@ -65,6 +68,7 @@ def test_concat_10():
     obj.run()
 
 
+@_test_with_pir
 def test_concat_11():
     """
     api: paddle.concat
@@ -81,6 +85,7 @@ def test_concat_11():
     obj.run()
 
 
+@_test_with_pir
 def test_concat_12():
     """
     api: paddle.concat

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -47,6 +48,7 @@ class Net2(paddle.nn.Layer):
         x = paddle.split(inputs, num_or_sections=[2,3,5], axis=-1)
         return x
     
+@_test_with_pir
 def test_split_v7_1():
     """
     api: paddle.split
@@ -63,6 +65,7 @@ def test_split_v7_1():
 
 
 
+@_test_with_pir
 def test_split_v7_2():
     """
     api: paddle.split
@@ -76,6 +79,7 @@ def test_split_v7_2():
                            randtool("float", -1, 1, [3, 10]).astype('float32')))
     obj.run()
 
+@_test_with_pir
 def test_split_v13_1():
     """
     api: paddle.split
@@ -91,6 +95,7 @@ def test_split_v13_1():
     obj.run()
 
 
+@_test_with_pir
 def test_split_v13_2():
     """
     api: paddle.split
@@ -105,6 +110,8 @@ def test_split_v13_2():
                            randtool("float", -1, 1, [3, 10]).astype('float32')))
     obj.run()
 
+
+@_test_with_pir
 def test_split_v18_1():
     """
     api: paddle.split
@@ -120,6 +127,7 @@ def test_split_v18_1():
     obj.run()
 
 
+@_test_with_pir
 def test_split_v18_2():
     """
     api: paddle.split

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -15,6 +15,7 @@
 import paddle
 from onnxbase import APIOnnx
 from onnxbase import randtool
+from onnxbase import _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +34,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_transpose_9():
     """
     api: paddle.transpose
@@ -49,6 +51,7 @@ def test_transpose_9():
     obj.run()
 
 
+@_test_with_pir
 def test_transpose_10():
     """
     api: paddle.transpose
@@ -65,6 +68,7 @@ def test_transpose_10():
     obj.run()
 
 
+@_test_with_pir
 def test_transpose_11():
     """
     api: paddle.transpose
@@ -81,6 +85,7 @@ def test_transpose_11():
     obj.run()
 
 
+@_test_with_pir
 def test_transpose_12():
     """
     api: paddle.transpose


### PR DESCRIPTION
支持以下算子在PIR下的转化：
1. concat，非新增算子，完善单测`test_concat.py`, `test_auto_scan_concat.py`
2. split，非新增算子，完善单测`test_split.py`, `test_auto_scan_split.py`
3. split_with_num，**新增算子**，但是可复用split算子的mapper，主要区分在使用`num` 还是`section`，完善单测`test_split.py`, `test_auto_scan_split.py`
4. transpose，非新增算子，其旧IR下算子名为`transpose2`，完善单测`test_transpose.py`, `test_auto_scan_transpose.py`

**备注：**
* 在测试split算子时还涉及了未支持的算子`assign_value_`，目前对其仅仅完成了注册，完善并测试它的单测文件