### PR TITLE
Fallback to old IR in paddlepaddle 3.0.0b2

### DIFF
--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -16,6 +16,21 @@ import os
 import paddle
 import paddle2onnx.paddle2onnx_cpp2py_export as c_p2o
 from paddle2onnx.utils import logging, paddle_jit_save_configs
+from contextlib import contextmanager
+
+
+def get_old_ir_guard():
+    # For old version of PaddlePaddle, donothing guard is returned.
+    @contextmanager
+    def dummy_guard():
+        yield
+
+    if not hasattr(paddle, "pir_utils"):
+        return dummy_guard
+    pir_utils = paddle.pir_utils
+    if not hasattr(pir_utils, "DygraphOldIrGuard"):
+        return dummy_guard
+    return pir_utils.DygraphOldIrGuard
 
 def export(model_filename,
            params_filename,
@@ -66,9 +81,13 @@ def dygraph2onnx(layer, save_file, input_spec=None, opset_version=9, **configs):
         if os.path.isfile(params_file):
             os.remove(params_file)
     save_configs = paddle_jit_save_configs(configs)
-    paddle.jit.save(
-        layer, os.path.join(paddle_model_dir, "model"), input_spec, **save_configs
-    )
+    with get_old_ir_guard()():
+        # In PaddlePaddle 3.0.0b2, PIR becomes the default IR, but PIR export still in development.
+        # So we need to use the old IR to export the model, avoid make users confused.
+        # In the future, we will remove this guard and recommend users to use PIR.
+        paddle.jit.save(
+            layer, os.path.join(paddle_model_dir, "model"), input_spec, **save_configs
+        )
     logging.info("Static PaddlePaddle model saved in {}.".format(paddle_model_dir))
     if not os.path.isfile(params_file):
         params_file = ""


### PR DESCRIPTION
fixes PaddlePaddle/Paddle#69128

在 PIR 2ONNX 导出尚未 ready 的现在，当使用动态图直接导出时，`jit.save` 处暂时使用老 IR 以确保用户是无感的

当然后续 PIR ready 后应该且推荐使用 PIR

@Zheng-Bicheng 看看如何，没啥问题感觉可以发个新版本，以匹配 PaddlePaddle 3.0.0b2