### PR TITLE
【PIR】Fix issues with inference of LaTeX_OCR_rec model

### DIFF
--- a/paddle2onnx/mapper/tensor/reduce_max.cc
+++ b/paddle2onnx/mapper/tensor/reduce_max.cc
@@ -68,6 +68,9 @@ void ReduceMaxMapper::Opset18() {
     input_name = helper_->AutoCast(input_name, input_tpye, P2ODataType::INT32);
     input_tpye = P2ODataType::INT32;
   }
+  if(x_info[0].Rank() == 0) {
+    input_name = helper_->Unsqueeze(input_name, {0});
+  }
   auto reduce_node = helper_->MakeNode("ReduceMax", {input_name, dims});
 
   // Add attribute

--- a/paddle2onnx/mapper/tensor/repeat_interleave.cc
+++ b/paddle2onnx/mapper/tensor/repeat_interleave.cc
@@ -46,8 +46,8 @@ namespace paddle2onnx {
     }
 
     std::string repeat_info_name = "";
-    if (HasInput("RepeatsTensor")) {
-        auto tmp_info = GetInput("RepeatsTensor");
+    if (HasInput("RepeatTensor")) {
+        auto tmp_info = GetInput("RepeatTensor");
         repeat_info_name = helper_->AutoCast(tmp_info[0].name,
                                               tmp_info[0].dtype,
                                               P2ODataType::INT64);

--- a/paddle2onnx/mapper/tensor/scale.cc
+++ b/paddle2onnx/mapper/tensor/scale.cc
@@ -70,8 +70,22 @@ void ScaleMapper::Opset7() {
         }
       }
     }
-    std::string reshape_out = helper_->Reshape(out, output_info[0].shape);
-    helper_->AutoCast(reshape_out, output_info[0].name, P2ODataType::FP32,
+    int32_t cnt = 0;
+    for (auto i : output_info[0].shape) {
+      if (i == -1) cnt++;
+    }
+    std::string reshape_out;
+    if (cnt > 1) {
+      auto input_shape =
+          helper_->MakeNode("Shape", {input_info[0].name})->output(0);
+      reshape_out = helper_->MakeNode("Reshape", {out, input_shape})->output(0);
+    } else {
+      reshape_out = helper_->Reshape(out, output_info[0].shape);
+    }
+
+    helper_->AutoCast(reshape_out,
+                      output_info[0].name,
+                      P2ODataType::FP32,
                       output_info[0].dtype);
   }
 }


### PR DESCRIPTION
1.  failed:Node (p2o.Split.6) Op (Split) [ShapeInferenceError] Mismatch between the sum of 'split' (1) and the split dimension of the input (0)
2. failed:Node (p2o.ReduceMax.2) Op (ReduceMax) [ShapeInferenceError] axis must be in [-rank, rank-1]. input rank was 0
3. failed:Node (p2o.Reshape.284) Op (Reshape) [ShapeInferenceError] Target shape may not have multiple -1 dimensions.