### PR TITLE
Support compilation and loading on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(paddle2onnx C CXX)
 # ONNX 1.16 requires C++ 17
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Build the libraries with - fPIC
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Always link with libstdc++ fs.a when using GCC 8.
@@ -11,7 +12,11 @@ link_libraries(
 
 option(WITH_STATIC "Compile Paddle2ONNX with  STATIC" OFF)
 option(PADDLE2ONNX_DEBUG "If open the debug log while converting model" OFF)
-option(MSVC_STATIC_CRT "Compile Paddle2ONNX with  MSVC STATIC CRT" ON)
+option(MSVC_STATIC_CRT "Compile Paddle2ONNX with  MSVC STATIC CRT" OFF)
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  add_definitions(-DPADDLE_WITH_TESTING)
+endif()
 
 if(PADDLE2ONNX_DEBUG)
   add_definitions(-DPADDLE2ONNX_DEBUG)
@@ -31,7 +36,7 @@ if(WITH_STATIC)
   add_definitions(-DWITH_PADDLE2ONNX_STATIC_INTERNAL_AT_COMPILING)
 endif()
 
-include(cmake/utils.cmake)
+include(utils)
 configure_file(${PROJECT_SOURCE_DIR}/paddle2onnx/mappers_registry.h.in
                ${PROJECT_SOURCE_DIR}/paddle2onnx/mappers_registry.h)
 
@@ -94,22 +99,33 @@ else()
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   message(STATUS "Python site-packages directory: ${PYTHON_SITE_PACKAGES}")
 
-  # set(PADDLE_LIB ${PYTHON_SITE_PACKAGES}/paddle/base/libpaddle.so)
-  set(PADDLE_LIB "${PYTHON_SITE_PACKAGES}/paddle/base/libpaddle.so")
-  if(EXISTS ${PADDLE_LIB})
-    message(STATUS "found libpaddle.so : ${PADDLE_LIB}")
+  if(MSVC)
+    include(external/paddle)
+    # add paddle include dir
+    set(PADDLE_INCLUDE_DIR ${LIBPADDLE_INCLUDE_DIR})
+    set(PADDLE_LIB ${LIBPADDLE_BASE_LIBRARY})
+    set(COMMON_LIB ${LIBPADDLE_COMMON_LIBRARY})
   else()
-    message(FATAL_ERROR "not found libpaddle.so!")
+    set(PADDLE_LIB "${PYTHON_SITE_PACKAGES}/paddle/base/libpaddle.so")
+    if(EXISTS ${PADDLE_LIB})
+      message(STATUS "Found libpaddle.so : ${PADDLE_LIB}.")
+    else()
+      message(
+        FATAL_ERROR
+          "Can not found libpaddle.so at ${PYTHON_SITE_PACKAGES}/paddle/base!")
+    endif()
+    # add paddle include dir
+    set(PADDLE_INCLUDE_DIR ${PYTHON_SITE_PACKAGES}/paddle/include/)
   endif()
 
-  # add paddle include dir
-  set(PADDLE_INCLUDE_DIR ${PYTHON_SITE_PACKAGES}/paddle/include/)
   include_directories(${PADDLE_INCLUDE_DIR})
   if(APPLE)
     set_target_properties(paddle2onnx PROPERTIES LINK_FLAGS
                                                  "-undefined dynamic_lookup")
   elseif(MSVC)
     message("------ BUILD WITH MSVC --------")
+    # remove `interface` macro defined in MSVC
+    # target_compile_options(paddle2onnx PRIVATE /Uinterface)
   else()
     set_target_properties(paddle2onnx PROPERTIES COMPILE_FLAGS
                                                  "-fvisibility=hidden")
@@ -118,8 +134,14 @@ else()
     set_target_properties(paddle2onnx PROPERTIES LINK_FLAGS_RELEASE -s)
   endif()
   set_target_properties(paddle2onnx PROPERTIES VERSION ${PADDLE2ONNX_VERSION})
-  target_link_libraries(paddle2onnx ${PADDLE_LIB} p2o_paddle_proto onnx
-                        pybind11::embed glog::glog)
+  target_link_libraries(
+    paddle2onnx
+    ${PADDLE_LIB}
+    ${COMMON_LIB}
+    p2o_paddle_proto
+    onnx
+    pybind11::embed
+    glog::glog)
 endif()
 
 if(WIN32)
@@ -141,6 +163,12 @@ install(FILES ${PROJECT_SOURCE_DIR}/paddle2onnx/converter.h
         DESTINATION include/paddle2onnx)
 
 if(BUILD_PADDLE2ONNX_PYTHON)
+  if(APPLE)
+    find_program(INSTALL_NAME_TOOL_EXECUTABLE install_name_tool)
+    if(NOT INSTALL_NAME_TOOL_EXECUTABLE)
+      message(FATAL_ERROR "install_name_tool not found, please check.\n")
+    endif()
+  endif()
   if("${PY_EXT_SUFFIX}" STREQUAL "")
     if(MSVC)
       set(PY_EXT_SUFFIX ".pyd")
@@ -194,8 +222,9 @@ if(BUILD_PADDLE2ONNX_PYTHON)
                           PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
   endif()
 
-  target_link_libraries(paddle2onnx_cpp2py_export
-                        PRIVATE ${PADDLE_LIB} p2o_paddle_proto onnx glog::glog)
+  target_link_libraries(
+    paddle2onnx_cpp2py_export PRIVATE ${PADDLE_LIB} ${COMMON_LIB}
+                                      p2o_paddle_proto onnx glog::glog)
 
   if(MSVC)
     target_link_libraries(paddle2onnx_cpp2py_export PRIVATE ${PYTHON_LIBRARIES})

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include cmake *
 recursive-include paddle2onnx *
 recursive-include third_party *
+recursive-include patch *
 
 include LICENSE
 include VERSION_NUMBER

--- a/cmake/external/paddle.cmake
+++ b/cmake/external/paddle.cmake
@@ -1,0 +1,33 @@
+include(ExternalProject)
+
+ExternalProject_Add(
+  paddle_project
+  PREFIX ${CMAKE_BINARY_DIR}/third_party/paddle
+  URL https://paddle2onnx.bj.bcebos.com/paddle_windows/paddle-win_amd64.zip
+  DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/third_party/paddle/downloads
+  SOURCE_DIR ${CMAKE_BINARY_DIR}/third_party/paddle/libpaddle
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  PATCH_COMMAND
+    ${CMAKE_COMMAND} -E echo "Patching files" && ${CMAKE_COMMAND} -E
+    copy_if_different ${CMAKE_SOURCE_DIR}/patch/paddle/interface_support.h
+    ${CMAKE_BINARY_DIR}/third_party/paddle/libpaddle/include/paddle/pir/include/core/interface_support.h
+)
+set(LIBPADDLE_INCLUDE_DIR
+    "${CMAKE_BINARY_DIR}/third_party/paddle/libpaddle/include")
+set(LIBPADDLE_BASE_LIBRARY
+    "${CMAKE_BINARY_DIR}/third_party/paddle/libpaddle/libpaddle.lib")
+set(LIBPADDLE_COMMON_LIBRARY
+    "${CMAKE_BINARY_DIR}/third_party/paddle/libpaddle/common.lib")
+
+add_library(libpaddle_base SHARED IMPORTED)
+set_target_properties(libpaddle_base PROPERTIES IMPORTED_LOCATION
+                                                ${LIBPADDLE_BASE_LIBRARY})
+add_library(libpaddle_common SHARED IMPORTED)
+set_target_properties(libpaddle_common PROPERTIES IMPORTED_LOCATION
+                                                  ${LIBPADDLE_COMMON_LIBRARY})
+# Ensure the download is complete before building the project
+add_dependencies(paddle2onnx paddle_project)
+# if(BUILD_PADDLE2ONNX_PYTHON) add_dependencies(paddle2onnx_cpp2py_export
+# paddle_project) endif()

--- a/paddle2onnx/__init__.py
+++ b/paddle2onnx/__init__.py
@@ -11,6 +11,76 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+import sys
+import ctypes
+import glob
+
+if sys.platform == "win32":
+    pfiles_path = os.getenv("ProgramFiles", "C:\\Program Files")
+    py_dll_path = os.path.join(sys.exec_prefix, "Library", "bin")
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    libs_path = os.path.join(package_dir, "libs")
+
+    if sys.exec_prefix != sys.base_exec_prefix:
+        base_py_dll_path = os.path.join(sys.base_exec_prefix, "Library", "bin")
+    else:
+        base_py_dll_path = ""
+
+    dll_paths = list(filter(os.path.exists, [libs_path]))
+
+    kernel32 = ctypes.WinDLL("kernel32.dll", use_last_error=True)
+    with_load_library_flags = hasattr(kernel32, "AddDllDirectory")
+    prev_error_mode = kernel32.SetErrorMode(0x0001)
+
+    kernel32.LoadLibraryW.restype = ctypes.c_void_p
+    if with_load_library_flags:
+        kernel32.LoadLibraryExW.restype = ctypes.c_void_p
+
+    dlls = None
+    for dll_path in dll_paths:
+        os.add_dll_directory(dll_path)
+        dlls = glob.glob(os.path.join(dll_path, "*.dll"))
+
+    try:
+        ctypes.CDLL("vcruntime140.dll")
+        ctypes.CDLL("msvcp140.dll")
+        ctypes.CDLL("vcruntime140_1.dll")
+    except OSError:
+        print(
+            """Microsoft Visual C++ Redistributable is not installed, this may lead to the DLL load failure.
+                It can be downloaded at https://aka.ms/vs/16/release/vc_redist.x64.exe"""
+        )
+
+    # Not load 32 bit dlls in 64 bit python.
+    dlls = [dll for dll in dlls if "32_" not in dll]
+    path_patched = False
+    for dll in dlls:
+        is_loaded = False
+        if with_load_library_flags:
+            res = kernel32.LoadLibraryExW(dll, None, 0x00001100)
+            last_error = ctypes.get_last_error()
+            if res is None and last_error != 126:
+                err = ctypes.WinError(last_error)
+                err.strerror += f' Error loading "{dll}" or one of its dependencies.'
+                raise err
+            elif res is not None:
+                is_loaded = True
+        if not is_loaded:
+            if not path_patched:
+                prev_path = os.environ["PATH"]
+                os.environ["PATH"] = ";".join(dll_paths + [os.environ["PATH"]])
+                path_patched = True
+            res = kernel32.LoadLibraryW(dll)
+            if path_patched:
+                os.environ["PATH"] = prev_path
+            if res is None:
+                err = ctypes.WinError(ctypes.get_last_error())
+                err.strerror += f' Error loading "{dll}" or one of its dependencies.'
+                raise err
+    kernel32.SetErrorMode(prev_error_mode)
+
 from .version import version
 from .convert import export
 from .convert import dygraph2onnx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "cmake>=3.16",
     "setuptools-scm",
-    "paddlepaddle==3.0.0.dev20241118",
+    "paddlepaddle==3.0.0.dev20241211",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,17 @@ import subprocess
 import sys
 import platform
 import multiprocessing
+import glob
+import shutil
 
 TOP_DIR = os.path.realpath(os.path.dirname(__file__))
-SRC_DIR = os.path.join(TOP_DIR, 'paddle2onnx')
-CMAKE_BUILD_DIR = os.path.join(TOP_DIR, '.setuptools-cmake-build')
+SRC_DIR = os.path.join(TOP_DIR, "paddle2onnx")
+CMAKE_BUILD_DIR = os.path.join(TOP_DIR, ".setuptools-cmake-build")
 
-WINDOWS = (os.name == 'nt')
+WINDOWS = os.name == "nt"
 
-CMAKE = find_executable('cmake3') or find_executable('cmake')
-MAKE = find_executable('make')
+CMAKE = find_executable("cmake3") or find_executable("cmake")
+MAKE = find_executable("make")
 
 ################################################################################
 # Global variables for controlling the build variant
@@ -43,8 +45,8 @@ MAKE = find_executable('make')
 
 # Default value is set to TRUE\1 to keep the settings same as the current ones.
 # However going forward the recomemded way to is to set this to False\0
-USE_MSVC_STATIC_RUNTIME = bool(os.getenv('USE_MSVC_STATIC_RUNTIME', '1') == '1')
-ONNX_NAMESPACE = os.getenv('ONNX_NAMESPACE', 'onnx')
+USE_MSVC_STATIC_RUNTIME = bool(os.getenv("USE_MSVC_STATIC_RUNTIME", "1") == "1")
+ONNX_NAMESPACE = os.getenv("ONNX_NAMESPACE", "onnx")
 
 ################################################################################
 # Pre Check
@@ -60,7 +62,7 @@ assert CMAKE, 'Could not find "cmake" executable!'
 @contextmanager
 def cd(path):
     if not os.path.isabs(path):
-        raise RuntimeError('Can only cd to absolute path, got: {}'.format(path))
+        raise RuntimeError("Can only cd to absolute path, got: {}".format(path))
     orig_path = os.getcwd()
     os.chdir(path)
     try:
@@ -73,6 +75,7 @@ def cd(path):
 # Customized commands
 ################################################################################
 
+
 class cmake_build(setuptools.Command):
     """
     Compiles everything when `python setupmnm.py build` is run using cmake.
@@ -81,8 +84,10 @@ class cmake_build(setuptools.Command):
     The number of CPUs used by `make` can be specified by passing `-j<ncpus>`
     to `setup.py build`.  By default all CPUs are used.
     """
-    user_options = [(str('jobs='), str('j'),
-                     str('Specifies the number of jobs to use with make'))]
+
+    user_options = [
+        (str("jobs="), str("j"), str("Specifies the number of jobs to use with make"))
+    ]
 
     built = False
 
@@ -91,62 +96,69 @@ class cmake_build(setuptools.Command):
 
     def finalize_options(self):
         if sys.version_info[0] >= 3:
-            self.set_undefined_options('build', ('parallel', 'jobs'))
+            self.set_undefined_options("build", ("parallel", "jobs"))
         if self.jobs is None and os.getenv("MAX_JOBS") is not None:
             self.jobs = os.getenv("MAX_JOBS")
-        self.jobs = multiprocessing.cpu_count() if self.jobs is None else int(
-            self.jobs)
+        self.jobs = multiprocessing.cpu_count() if self.jobs is None else int(self.jobs)
 
     def run(self):
         os.makedirs(CMAKE_BUILD_DIR, exist_ok=True)
 
         with cd(CMAKE_BUILD_DIR):
-            build_type = 'Release'
+            build_type = "Release"
             # configure
             cmake_args = [
                 CMAKE,
-                '-DPYTHON_INCLUDE_DIR={}'.format(sysconfig.get_python_inc()),
-                '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
-                '-DBUILD_PADDLE2ONNX_PYTHON=ON',
-                '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-                '-DONNX_NAMESPACE={}'.format(ONNX_NAMESPACE),
-                '-DPY_EXT_SUFFIX={}'.format(sysconfig.get_config_var('EXT_SUFFIX') or ''),
-                '-DPY_VERSION={}'.format(str(sys.version_info[0])+'.'+str(sys.version_info[1])),
+                "-DPYTHON_INCLUDE_DIR={}".format(sysconfig.get_python_inc()),
+                "-DPYTHON_EXECUTABLE={}".format(sys.executable),
+                "-DBUILD_PADDLE2ONNX_PYTHON=ON",
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+                "-DONNX_NAMESPACE={}".format(ONNX_NAMESPACE),
+                "-DPY_EXT_SUFFIX={}".format(
+                    sysconfig.get_config_var("EXT_SUFFIX") or ""
+                ),
+                "-DPY_VERSION={}".format(
+                    str(sys.version_info[0]) + "." + str(sys.version_info[1])
+                ),
             ]
-            cmake_args.append('-DCMAKE_BUILD_TYPE=%s' % build_type)
+            cmake_args.append("-DCMAKE_BUILD_TYPE=%s" % build_type)
             if WINDOWS:
-                cmake_args.extend([
-                    # we need to link with libpython on windows, so
-                    # passing python version to window in order to
-                    # find python in cmake
-                    '-DPY_VERSION={}'.format('{0}.{1}'.format(* \
-                                                              sys.version_info[:2])),
-                ])
-                if platform.architecture()[0] == '64bit':
-                    cmake_args.extend(['-A', 'x64', '-T', 'host=x64'])
+                cmake_args.extend(
+                    [
+                        # we need to link with libpython on windows, so
+                        # passing python version to window in order to
+                        # find python in cmake
+                        "-DPY_VERSION={}".format(
+                            "{0}.{1}".format(*sys.version_info[:2])
+                        ),
+                    ]
+                )
+                if platform.architecture()[0] == "64bit":
+                    cmake_args.extend(["-A", "x64", "-T", "host=x64"])
                 else:
-                    cmake_args.extend(['-A', 'Win32', '-T', 'host=x86'])
-            if 'CMAKE_ARGS' in os.environ:
-                extra_cmake_args = shlex.split(os.environ['CMAKE_ARGS'])
+                    cmake_args.extend(["-A", "Win32", "-T", "host=x86"])
+                cmake_args.extend(["-G", "Visual Studio 16 2019"])
+            if "CMAKE_ARGS" in os.environ:
+                extra_cmake_args = shlex.split(os.environ["CMAKE_ARGS"])
                 # prevent crossfire with downstream scripts
-                del os.environ['CMAKE_ARGS']
-                log.info('Extra cmake args: {}'.format(extra_cmake_args))
+                del os.environ["CMAKE_ARGS"]
+                log.info("Extra cmake args: {}".format(extra_cmake_args))
                 cmake_args.extend(extra_cmake_args)
             cmake_args.append(TOP_DIR)
             subprocess.check_call(cmake_args)
 
-            build_args = [CMAKE, '--build', os.curdir]
+            build_args = [CMAKE, "--build", os.curdir]
             if WINDOWS:
-                build_args.extend(['--config', build_type])
-                build_args.extend(['--', '/maxcpucount:{}'.format(self.jobs)])
+                build_args.extend(["--config", build_type])
+                build_args.extend(["--", "/maxcpucount:{}".format(self.jobs)])
             else:
-                build_args.extend(['--', '-j', str(self.jobs)])
+                build_args.extend(["--", "-j", str(self.jobs)])
             subprocess.check_call(build_args)
 
 
 class build_ext(setuptools.command.build_ext.build_ext):
     def run(self):
-        self.run_command('cmake_build')
+        self.run_command("cmake_build")
         return super().run()
 
     def build_extensions(self):
@@ -166,14 +178,35 @@ class build_ext(setuptools.command.build_ext.build_ext):
                     lib_path = debug_lib_dir
                 elif os.path.exists(release_lib_dir):
                     lib_path = release_lib_dir
+                # copy paddle libs
+                os.makedirs(os.path.join(extension_dst_dir, "libs"), exist_ok=True)
+                source_pattern = os.path.join(
+                    CMAKE_BUILD_DIR, "third_party", "paddle", "libpaddle", "*.dll"
+                )
+                dest_dir = os.path.join(extension_dst_dir, "libs")
+                for file_path in glob.glob(source_pattern):
+                    shutil.copy(file_path, dest_dir)
+
             src = os.path.join(lib_path, filename)
             dst = os.path.join(
-                os.path.realpath(self.build_lib), "paddle2onnx", filename)
+                os.path.realpath(self.build_lib), "paddle2onnx", filename
+            )
+            if platform.system() == "Darwin":
+                command = "install_name_tool -change @loader_path/../libs/ @loader_path/../paddle/base/libpaddle.so {}".format(
+                    src
+                )
+                if os.system(command) != 0:
+                    raise Exception(
+                        "Failed to change library paths using command: '{}'".format(
+                            command
+                        )
+                    )
             self.copy_file(src, dst)
 
+
 cmdclass = {
-    'cmake_build': cmake_build,
-    'build_ext': build_ext,
+    "cmake_build": cmake_build,
+    "build_ext": build_ext,
 }
 
 ################################################################################
@@ -181,8 +214,7 @@ cmdclass = {
 ################################################################################
 
 ext_modules = [
-    setuptools.Extension(
-        name=str('paddle2onnx.paddle2onnx_cpp2py_export'), sources=[])
+    setuptools.Extension(name=str("paddle2onnx.paddle2onnx_cpp2py_export"), sources=[])
 ]
 
 ################################################################################


### PR DESCRIPTION
* The dependencies `libpaddle` and `common` are required on Windows, but their corresponding DLL files are not present in `pythonX.Y/site-packages/paddle`. Therefore, the necessary DLL files should be downloaded as third-party libraries during the compilation process.
* Package the DLL files and proactively load them.
* Modify the code in the Paddle repository to export the corresponding symbols and resolve symbol definition conflicts