### PR TITLE
Fix issues with inference of onnx models converted from paddlex

### DIFF
--- a/paddle2onnx/mapper/detection/multiclass_nms.cc
+++ b/paddle2onnx/mapper/detection/multiclass_nms.cc
@@ -138,7 +138,7 @@ void NMSMapper::KeepTopK(const std::string& selected_indices) {
     AddAttribute(ensemble_value, "axis", int64_t(0));
 
     std::shared_ptr<ONNX_NAMESPACE::NodeProto> new_top_k;
-    if (OnnxHelper::GetOpsetVersion() > 13) {
+    if (OnnxHelper::GetOpsetVersion() >= 18) {
       std::string reduce_min_axis = helper_->Constant(
           {1}, ONNX_NAMESPACE::TensorProto::INT64, static_cast<int64_t>(0));
       new_top_k = helper_->MakeNode(

--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -200,32 +200,76 @@ int32_t ModelExporter::GetMinOpsetVersion(const PaddleParser& parser) {
   return max_opset;
 }
 
-int32_t ModelExporter::GetMinOpsetVersion(const PaddlePirParser& pir_parser) {
+int32_t ModelExporter::GetCfBlockMinOpsetVersion(
+    const PaddlePirParser& pir_parser, pir::Block& block) {
+  std::vector<pir::Operation*> sub_blocks_ops_copy(pir_parser.sub_blocks_ops);
+  pir_parser.sub_blocks_ops.clear();
+  std::vector<pir::Operation*> block_ops;
+  for (auto& op : block.ops()) {
+    if (op->name() != "builtin.parameter") {
+      pir_parser.sub_blocks_ops.push_back(op);
+    }
+  }
+  auto max_opset = GetMinOpsetVersion(pir_parser, &block, true);
+  pir_parser.sub_blocks_ops.clear();
+  pir_parser.sub_blocks_ops = sub_blocks_ops_copy;
+  return max_opset;
+}
+
+int32_t ModelExporter::GetMinOpsetVersion(const PaddlePirParser& pir_parser,
+                                          pir::Block* block,
+                                          bool if_in_sublock) {
   int32_t max_opset = 7;
   std::set<std::string> verbose_log;
   OnnxHelper helper;
-  // TODO(wangmingkai02): consider the case of cf op
-  for (auto i = 0; i < pir_parser.global_blocks_ops.size(); i++) {
-    std::string op_name = pir_parser.global_blocks_ops[i]->name();
-    if (op_name == "pd_op.data" || op_name == "pd_op.fetch") {
+  std::vector<pir::Operation*> block_ops;
+  for (auto& op :
+       block->ops()) {  // it's  necessary to be same with global/sub_blocks_ops
+    if (op->name() == "builtin.parameter") {
       continue;
     }
-    if (op_name == "pd_op.if" || op_name == "pd_op.while") {
+    block_ops.push_back(op);
+  }
+  for (auto i = 0; i < block_ops.size(); ++i) {
+    auto op = block_ops[i];
+    std::string op_name = op->name();
+    if (op_name == "pd_op.data" || op_name == "pd_op.fetch" ||
+        op_name == "pd_op.yeild") {
       continue;
     }
     int current_opset = 7;
-    auto mapper = MapperHelper::Get()->CreateMapper(
-        convert_pir_op_name(op_name), pir_parser, &helper, i, false);
-    current_opset = mapper->GetMinOpsetVersion(verbose_);
-    delete mapper;
+    if (op_name == "pd_op.if") {
+      auto if_op = op->dyn_cast<paddle::dialect::IfOp>();
+      pir::Block& true_block = if_op.true_block();
+      auto true_block_opset_version =
+          GetCfBlockMinOpsetVersion(pir_parser, true_block);
+      pir::Block& false_block = if_op.false_block();
+      auto false_block_opset_version =
+          GetCfBlockMinOpsetVersion(pir_parser, false_block);
+      current_opset = true_block_opset_version > false_block_opset_version
+                          ? true_block_opset_version
+                          : false_block_opset_version;
+      current_opset = current_opset > 11 ? current_opset : 11;
+    } else if (op_name == "pd_op.while") {
+      auto while_op = op->dyn_cast<paddle::dialect::WhileOp>();
+      current_opset = GetCfBlockMinOpsetVersion(pir_parser, while_op.body());
+      current_opset = current_opset > 11 ? current_opset : 11;
 
+    } else {
+      auto mapper = MapperHelper::Get()->CreateMapper(
+          convert_pir_op_name(op_name), pir_parser, &helper, i, if_in_sublock);
+      current_opset = mapper->GetMinOpsetVersion(verbose_);
+      delete mapper;
+    }
     if (current_opset > max_opset) {
       max_opset = current_opset;
       if (current_opset > opset_version_) {
-        verbose_log.insert(
-            "Due to the operator: " + pir_parser.global_blocks_ops[i]->name() +
-            " " + "requires opset_version >= " + std::to_string(current_opset) +
-            ".");
+        if (opset_version_ < 11 ||
+            (op_name != "pd_op.if" && op_name != "pd_op.while")) {
+          verbose_log.insert("Due to the operator: " + op_name + " " +
+                             "requires opset_version >= " +
+                             std::to_string(current_opset) + ".");
+        }
       }
     }
   }
@@ -240,7 +284,8 @@ void ModelExporter::SetOpsetVersion(const PaddlePirParser& pir_parser,
                                     bool auto_upgrade_opset) {
   bool opset_is_legal = true;
   // here
-  int32_t min_opset = GetMinOpsetVersion(pir_parser);
+  int32_t min_opset =
+      GetMinOpsetVersion(pir_parser, pir_parser.pir_program_->block(), false);
   if (min_opset < 7 || min_opset > MAX_ONNX_OPSET_VERSION) {
     P2OLogger(verbose_) << "The Opset Version must be between 7 and "
                         << MAX_ONNX_OPSET_VERSION << std::endl;
@@ -249,7 +294,7 @@ void ModelExporter::SetOpsetVersion(const PaddlePirParser& pir_parser,
   if (!auto_upgrade_opset) {
     if (min_opset > opset_version_) {
       P2OLogger(verbose_) << "Please set the opset_version to "
-                          << std::to_string(opset_version_)
+                          << std::to_string(min_opset)
                           << " or set auto_upgrade_opset=true." << std::endl;
       opset_is_legal = false;
     }

--- a/paddle2onnx/mapper/exporter.h
+++ b/paddle2onnx/mapper/exporter.h
@@ -157,8 +157,13 @@ class ModelExporter {
 
   ONNX_NAMESPACE::ModelProto onnx_model_;
   // Opset Version
+
+  int32_t GetCfBlockMinOpsetVersion(const PaddlePirParser& pir_parser,
+                                    pir::Block& block);
   int32_t GetMinOpsetVersion(const PaddleParser& parser);
-  int32_t GetMinOpsetVersion(const PaddlePirParser& parser);
+  int32_t GetMinOpsetVersion(const PaddlePirParser& pir_parser,
+                             pir::Block* block,
+                             bool if_in_sublock);
   void SetOpsetVersion(const PaddleParser& parser, bool auto_upgrade_opset);
   void SetOpsetVersion(const PaddlePirParser& pir_parser,
                        bool auto_upgrade_opset);

--- a/paddle2onnx/mapper/nn/interpolate.cc
+++ b/paddle2onnx/mapper/nn/interpolate.cc
@@ -132,7 +132,7 @@ void InterpolateMapper::Opset11() {
   }
   std::shared_ptr<ONNX_NAMESPACE::NodeProto> node;
   if (size != "") {
-    node = helper_->MakeNode("Resize", {x_info[0].name, roi, "", size},
+    node = helper_->MakeNode("Resize", {x_info[0].name, roi, scale, size},
                              {out_info[0].name});
   } else {
     node = helper_->MakeNode("Resize", {x_info[0].name, roi, scale},

--- a/paddle2onnx/mapper/nn/interpolate.cc
+++ b/paddle2onnx/mapper/nn/interpolate.cc
@@ -132,7 +132,7 @@ void InterpolateMapper::Opset11() {
   }
   std::shared_ptr<ONNX_NAMESPACE::NodeProto> node;
   if (size != "") {
-    node = helper_->MakeNode("Resize", {x_info[0].name, roi, scale, size},
+    node = helper_->MakeNode("Resize", {x_info[0].name, roi, "", size},
                              {out_info[0].name});
   } else {
     node = helper_->MakeNode("Resize", {x_info[0].name, roi, scale},

--- a/paddle2onnx/mapper/tensor/linspace.cc
+++ b/paddle2onnx/mapper/tensor/linspace.cc
@@ -53,6 +53,9 @@ void LinspaceMapper::Opset9() {
   std::string range_tensor = helper_->AutoCast(
       num_info[0].name, num_info[0].dtype, P2ODataType::INT64);
 
+  if(num_info[0].Rank() == 0) {
+    range_tensor = helper_->Unsqueeze(range_tensor, std::vector<int64_t>(1, 0));
+  }
   std::string one_like_node = helper_->ConstOfShape(
       range_tensor, GetOnnxDtype(P2ODataType::FP32), static_cast<float>(1));
 

--- a/paddle2onnx/mapper/tensor/set_value.cc
+++ b/paddle2onnx/mapper/tensor/set_value.cc
@@ -44,10 +44,10 @@ int32_t SetValueMapper::GetMinOpsetVersion(bool verbose) {
             << std::endl;
     return -1;
   }
-  return 12;
+  return 17;
 }
 
-void SetValueMapper::Opset12() {
+void SetValueMapper::Opset17() {
   auto input_info = GetInput("Input");
   auto output_info = GetOutput("Out");
   std::string starts = "";

--- a/paddle2onnx/mapper/tensor/set_value.h
+++ b/paddle2onnx/mapper/tensor/set_value.h
@@ -102,7 +102,7 @@ class SetValueMapper : public Mapper {
   }
 
   int32_t GetMinOpsetVersion(bool verbose) override;
-  void Opset12() override;
+  void Opset17() override;
 
  private:
   std::vector<int64_t> axes_;

--- a/paddle2onnx/mapper/while.cc
+++ b/paddle2onnx/mapper/while.cc
@@ -61,7 +61,8 @@ void ModelExporter::ExportWhile(PaddlePirParser& pir_parser,
     }
   }
 
-  pir_parser.GetAllSubBlockOpOutputName(pir_parser.sub_blocks_ops);
+  // generate sub-block op outputs names in GetMinOpSetVersion() function.
+  // pir_parser.GetAllSubBlockOpOutputName(pir_parser.sub_blocks_ops);
   if (!pir_parser.sub_blocks_ops.empty()) {
     // get cf.yeild op input
     pir::Operation* cf_yield_op = pir_parser.sub_blocks_ops.back();

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -35,7 +35,7 @@ class PaddlePirParser {
   // recoring set of operators for global block
   std::vector<pir::Operation*> global_blocks_ops;
   // recoring set of operators for sub block
-  std::vector<pir::Operation*>
+  mutable std::vector<pir::Operation*>
       sub_blocks_ops;  // todo(wangmingkai02): delete sub_blocks_ops
   // recording args of while op body name info
   std::unordered_map<pir::detail::ValueImpl*, pir::detail::ValueImpl*>

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -38,7 +38,6 @@ set ignore=!ignore! test_auto_scan_isx_ops.py
 set ignore=!ignore! test_auto_scan_masked_select.py
 set ignore=!ignore! test_auto_scan_pad2d.py
 set ignore=!ignore! test_auto_scan_roll.py
-set ignore=!ignore! test_auto_scan_set_value.py
 set ignore=!ignore! test_auto_scan_unfold.py
 set ignore=!ignore! test_auto_scan_uniform_random_batch_size_like.py
 set ignore=!ignore! test_auto_scan_uniform_random.py

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,7 +32,6 @@ ignore="test_auto_scan_multiclass_nms.py
         test_auto_scan_masked_select.py \
         test_auto_scan_pad2d.py \
         test_auto_scan_roll.py \
-        test_auto_scan_set_value.py \
         test_auto_scan_unfold.py \
         test_auto_scan_uniform_random_batch_size_like.py \
         test_auto_scan_uniform_random.py \

--- a/tests/test_auto_scan_set_value.py
+++ b/tests/test_auto_scan_set_value.py
@@ -38,7 +38,7 @@ class Net(BaseNet):
 class TestSetValueConvert(OPConvertAutoScanTest):
     """
     api: set_value
-    OPset version: 12, 13, 15
+    OPset version: 17, 19
     """
 
     def sample_convert_config(self, draw):
@@ -54,7 +54,7 @@ class TestSetValueConvert(OPConvertAutoScanTest):
             "op_names": ["set_value"],
             "test_data_shapes": [input_shape, update_input_shape],
             "test_data_types": [[dtype], [dtype]],
-            "opset_version": [12, 13, 14, 15],
+            "opset_version": [17, 19],
             "input_spec_shape": [],
         }
 


### PR DESCRIPTION
1. PicoDet类模型
    ```bash
    In Node, ("ReduceMin.0", ReduceMin, "", -1) : ("Concat.17": tensor(int64),"helper.constant.25": tensor(int64),) -> ("ReduceMin.1",) , Error Node (ReduceMin.0) has input size 2 not in range [min=1, max=1]. 
    ```
    multiclass_nms3中ReduceMin在opset version 14~17时输入不正确

2. SOLOv2
    ```bash
    RuntimeError: Node (ConstantOfShape.11) Op (ConstantOfShape) [ShapeInferenceError] shape input must be 1D tensor
    ```
    linspace op中输入Num是0-D tensor的情况需要特殊处理

3. SwinTransformer类模型
    ```
    In Node, ("If.0", If, "", -1) : ("Cast.15": tensor(bool),) -> ("p2o.pd_op.set_value_.0.0",) , Error No Op registered for SequenceMap with domain_version of 12 ==> Context: Bad node spec for node. Name: SequenceMap.0 OpType: SequenceMap
    ```
    opset version遗留问题：存在控制流OP时不能正确获取opset version的问题，导致算子转化失败

4. set_value opset version升级
    因为使用了ONNX的SequenceMap，需要opset version >= 17

5. 获取控制流中opset version时，部分算子的GetMinOpsetVersion中也需要获取TensorInfo信息，因此需要将获取控制流block中算子的输出名称提前到GetCfBlockMinOpsetVersion中