### PR TITLE
Fix the issue with determining whether operators in control flow are registered.

### DIFF
--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -41,14 +41,12 @@ bool ModelExporter::IsOpsRegistered(const PaddlePirParser& pir_parser,
                                     bool enable_experimental_op) {
   OnnxHelper temp_helper;
   std::set<std::string> unsupported_ops;
-  for (auto op : pir_parser.global_blocks_ops) {
+  for (auto op : pir_parser.total_blocks_ops) {
     if (op->name() == "pd_op.data" || op->name() == "pd_op.fetch") {
       continue;
     }
-    if (op->name() == "pd_op.if") {
-      continue;
-    }
-    if (op->name() == "pd_op.while") {
+    if (op->name() == "pd_op.if" || op->name() == "pd_op.while" ||
+        op->name() == "cf.yield") {
       continue;
     }
     std::string op_name = convert_pir_op_name(op->name());

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -37,6 +37,8 @@ class PaddlePirParser {
   // recoring set of operators for sub block
   mutable std::vector<pir::Operation*>
       sub_blocks_ops;  // todo(wangmingkai02): delete sub_blocks_ops
+  // recoring set of operators for all blocks
+  std::set<pir::Operation*> total_blocks_ops;
   // recording args of while op body name info
   std::unordered_map<pir::detail::ValueImpl*, pir::detail::ValueImpl*>
       while_op_input_value_map;
@@ -270,6 +272,7 @@ class PaddlePirParser {
   bool LoadParams(const std::string& path);
   bool GetParamValueName(std::vector<std::string>* var_names);
   void GetGlobalBlocksOps();
+  void GetAllBlocksOpsSet(pir::Block *block);
   void GetGlobalBlockInputOutputInfo();
   void GetGlobalBlockInputValueName();
   void GetGlobalBlockOutputValueName();


### PR DESCRIPTION
At the beginning of the export process, it is necessary to check for any unregistered operators. Previously, only the operators in the global block were checked, without verifying whether all operators within control flow were supported, which led to unclear error messages when issues arose during model conversion. 
Therefore, a new function `void GetAllBlocksOpsSet(pir::Block *block);`  has been added in `class PaddlePirParser`  to collect all operator pointers in the Program and perform checks at the start of the export process.
