### PR TITLE
Fix the issue with while op

### DIFF
--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -252,7 +252,7 @@ int32_t ModelExporter::GetMinOpsetVersion(const PaddlePirParser& pir_parser,
       current_opset = current_opset > 11 ? current_opset : 11;
     } else if (op_name == "pd_op.while") {
       auto while_op = op->dyn_cast<paddle::dialect::WhileOp>();
-      pir_parser.GetWhileInputValuesAndArgsMappings(while_op);
+      pir_parser.GetWhileInputValuesAndArgsMappings(&while_op);
       current_opset = GetCfBlockMinOpsetVersion(pir_parser, while_op.body());
       current_opset = current_opset > 11 ? current_opset : 11;
 

--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -252,6 +252,7 @@ int32_t ModelExporter::GetMinOpsetVersion(const PaddlePirParser& pir_parser,
       current_opset = current_opset > 11 ? current_opset : 11;
     } else if (op_name == "pd_op.while") {
       auto while_op = op->dyn_cast<paddle::dialect::WhileOp>();
+      pir_parser.GetWhileInputValuesAndArgsMappings(while_op);
       current_opset = GetCfBlockMinOpsetVersion(pir_parser, while_op.body());
       current_opset = current_opset > 11 ? current_opset : 11;
 
@@ -483,7 +484,7 @@ ONNX_NAMESPACE::GraphProto ModelExporter::ExportIfBlock(
       temp_outputs.push_back(std::move(MakeValueInfo(cond_info[0])));
       if (value.defining_op() == nullptr) {
         value =
-            pir::Value(pir_parser.while_op_input_value_map[&(*(value.impl()))]);
+            pir::Value(pir_parser.while_op_values_args_map[&(*(value.impl()))]);
       }
       if (value.defining_op()->GetParent() != &block) {
         temp_inputs.push_back(std::move(MakeValueInfo(cond_info[0])));

--- a/paddle2onnx/mapper/while.cc
+++ b/paddle2onnx/mapper/while.cc
@@ -30,7 +30,7 @@ void ModelExporter::ExportWhile(PaddlePirParser& pir_parser,
     inputs_info.push_back(pir_parser.GetTensorInfo(
         pir_parser.GetSubBlockOpOutputName(value), value.type()));
   }
-  pir_parser.GetWhileInputValuesAndArgsMappings(while_op);
+  pir_parser.GetWhileInputValuesAndArgsMappings(&while_op);
 
   std::vector<pir::Operation*> sub_blocks_ops_copy(pir_parser.sub_blocks_ops);
   pir_parser.sub_blocks_ops.clear();

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -1030,18 +1030,18 @@ P2ODataType PaddlePirParser::TransPirDataType2OldIrDataType(
   }
 }
 void PaddlePirParser::GetWhileInputValuesAndArgsMappings(
-    const paddle::dialect::WhileOp& while_op) const {
+    paddle::dialect::WhileOp* while_op) const {
   // mapping args and inputs in while op using while_op_values_args_map
   std::vector<pir::detail::ValueImpl*> while_op_input_value_address;
   std::vector<pir::detail::ValueImpl*> while_op_input_arg_address;
   // record input value address
-  for (int index = 1; index < while_op.num_operands(); index++) {
-    const pir::Value& value = while_op.operand_source(index);
+  for (int index = 1; index < while_op->num_operands(); index++) {
+    const pir::Value& value = while_op->operand_source(index);
     while_op_input_value_address.push_back(
         &(*(value).impl()));  // get value address
   }
   // record args value address
-  std::vector<pir::Value> args = while_op.block_args();
+  std::vector<pir::Value> args = while_op->block_args();
   for (int i = 0; i < args.size(); i++) {
     const pir::Value& value = args[i];
     while_op_input_arg_address.push_back(&(*(value.impl())));

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -22,6 +22,7 @@
 #include "paddle/pir/include/core/value.h"
 #include "paddle2onnx/parser/tensor_utils.h"
 #include "paddle2onnx/proto/p2o_paddle.pb.h"
+#include "paddle/fluid/pir/dialect/operator/ir/control_flow_op.h"
 namespace paddle2onnx {
 class PaddlePirParser {
  public:
@@ -40,8 +41,8 @@ class PaddlePirParser {
   // recoring set of operators for all blocks
   std::set<pir::Operation*> total_blocks_ops;
   // recording args of while op body name info
-  std::unordered_map<pir::detail::ValueImpl*, pir::detail::ValueImpl*>
-      while_op_input_value_map;
+  mutable std::unordered_map<pir::detail::ValueImpl*, pir::detail::ValueImpl*>
+      while_op_values_args_map;
   int NumOfBlocks() const;
   // int NumOfOps(int block_idx) const;
   int NumOfProgramOps() const;
@@ -265,6 +266,8 @@ class PaddlePirParser {
                           std::string tensor_arr_name) const;
   std::string GetTensorArrayName(int64_t op_id, bool if_in_sub_block) const;
   std::string GenOpInputOutputName(const std::string& name) const;
+  void GetWhileInputValuesAndArgsMappings(
+      const paddle::dialect::WhileOp& while_op) const;
 
  private:
   bool IsAttrVar(const pir::Operation* op, const int64_t& attr_id) const;

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -267,7 +267,7 @@ class PaddlePirParser {
   std::string GetTensorArrayName(int64_t op_id, bool if_in_sub_block) const;
   std::string GenOpInputOutputName(const std::string& name) const;
   void GetWhileInputValuesAndArgsMappings(
-      const paddle::dialect::WhileOp& while_op) const;
+      paddle::dialect::WhileOp *while_op) const;
 
  private:
   bool IsAttrVar(const pir::Operation* op, const int64_t& attr_id) const;


### PR DESCRIPTION
在某些算子中比如`set_value`，它的`GetMinOpsetVersion` 会调用`GetInput` 方法，当在控制流中时，会调用到`GetSubBlockOpOutputName`方法，在这之中会依赖`while_op_values_args_map` 数据结构，而`while_op_values_args_map` 只会在真正转化阶段才会构建，在`GetMinOpsetVersion` 中空数据，导致分支判断错误

解决方案：在`ModelExporter::GetMinOpsetVersion` 中增加对`while_op_values_args_map` 的处理