### PR TITLE
support op hardtanh & fix op unfold, empty, max_pool2d_with_index, max_pool3d_with_index

### DIFF
--- a/paddle2onnx/mapper/activation/activation.cc
+++ b/paddle2onnx/mapper/activation/activation.cc
@@ -84,7 +84,7 @@ REGISTER_PIR_MAPPER(sqrt, ActivationMapper)
 REGISTER_MAPPER(square, SquareMapper)
 REGISTER_PIR_MAPPER(square, SquareMapper)
 REGISTER_MAPPER(tan, ActivationMapper)
-REGISTER_PIR_MAPPER(hardtanh, ActivationMapper)
+// REGISTER_PIR_MAPPER(hardtanh, ActivationMapper)
 REGISTER_PIR_MAPPER(tan, ActivationMapper)
 REGISTER_MAPPER(tanh, ActivationMapper)
 REGISTER_PIR_MAPPER(tanh, ActivationMapper)
@@ -92,7 +92,6 @@ REGISTER_MAPPER(tanh_shrink, TanhShrinkMapper)
 REGISTER_PIR_MAPPER(tanh_shrink, TanhShrinkMapper)
 REGISTER_MAPPER(thresholded_relu, ThresholdedReluMapper)
 REGISTER_PIR_MAPPER(thresholded_relu, ThresholdedReluMapper)
-
 
 int32_t ActivationMapper::GetMinOpsetVersion(bool verbose) {
   if (convert_pir_op_name(OpType()) == "softplus") {
@@ -114,27 +113,23 @@ int32_t ActivationMapper::GetMinOpsetVersion(bool verbose) {
   return 7;
 }
 
-
 void ActivationMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
   auto iter = op_mapper_.find(convert_pir_op_name(OpType()));
   Assert(op_mapper_.end() != iter,
-         "Cannot find " +
-         convert_pir_op_name(OpType()) +
-         " in activation op_mapper.");
+         "Cannot find " + convert_pir_op_name(OpType()) +
+             " in activation op_mapper.");
   if (convert_pir_op_name(OpType()) == "erf") {
-    auto input = helper_->AutoCast(input_info[0].name, input_info[0].dtype,
-                                   P2ODataType::FP32);
+    auto input = helper_->AutoCast(
+        input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
     auto output = helper_->MakeNode(iter->second, {input})->output(0);
-    helper_->AutoCast(output, output_info[0].name, P2ODataType::FP32,
-                      output_info[0].dtype);
-  } else{
-      helper_->MakeNode(iter->second, {input_info[0].name},
-                      {output_info[0].name});
+    helper_->AutoCast(
+        output, output_info[0].name, P2ODataType::FP32, output_info[0].dtype);
+  } else {
+    helper_->MakeNode(
+        iter->second, {input_info[0].name}, {output_info[0].name});
   }
-
-
 }
 
 int32_t PReluMapper::GetMinOpsetVersion(bool verbose) {
@@ -158,8 +153,8 @@ void PReluMapper::Opset7() {
 
   std::string slope_cast_name = slope_info[0].name;
   if (slope_info[0].dtype == P2ODataType::FP64) {
-    slope_cast_name = helper_->AutoCast({slope_info[0].name}, P2ODataType::FP64,
-                                        P2ODataType::FP32);
+    slope_cast_name = helper_->AutoCast(
+        {slope_info[0].name}, P2ODataType::FP64, P2ODataType::FP32);
   }
 
   if (slope_info[0].Rank() != input_info[0].Rank()) {
@@ -178,11 +173,13 @@ void PReluMapper::Opset7() {
     std::string x_cast_name = helper_->AutoCast(
         {input_info[0].name}, P2ODataType::FP64, P2ODataType::FP32);
     auto node = helper_->MakeNode("PRelu", {x_cast_name, slope_cast_name});
-    helper_->AutoCast(node->output(0), {output_info[0].name}, P2ODataType::FP32,
+    helper_->AutoCast(node->output(0),
+                      {output_info[0].name},
+                      P2ODataType::FP32,
                       P2ODataType::FP64);
   } else {
-    helper_->MakeNode("PRelu", {input_info[0].name, slope_cast_name},
-                      {output_info[0].name});
+    helper_->MakeNode(
+        "PRelu", {input_info[0].name, slope_cast_name}, {output_info[0].name});
   }
 }
 
@@ -198,8 +195,8 @@ void SeluMapper::Opset7() {
 void LeakyReluMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
-  auto node = helper_->MakeNode("LeakyRelu", {input_info[0].name},
-                                {output_info[0].name});
+  auto node = helper_->MakeNode(
+      "LeakyRelu", {input_info[0].name}, {output_info[0].name});
   AddAttribute(node, "alpha", alpha_);
 }
 
@@ -217,8 +214,8 @@ void GeluMapper::Opset9() {
   auto const_1 =
       helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, const_1_value);
 
-  auto input_name = helper_->AutoCast(input_info[0].name, input_info[0].dtype,
-                                      P2ODataType::FP32);
+  auto input_name = helper_->AutoCast(
+      input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
 
   // the computation formula follows
   // https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/gelu_cn.html#gelu
@@ -250,8 +247,8 @@ void SoftMaxMapper::Opset7() {
       axis_ = axis_ + output_info[0].Rank();
     }
     if (axis_ == output_info[0].Rank() - 1) {
-      auto node = helper_->MakeNode("Softmax", {input_info[0].name},
-                                    {output_info[0].name});
+      auto node = helper_->MakeNode(
+          "Softmax", {input_info[0].name}, {output_info[0].name});
       AddAttribute(node, "axis", axis_);
     } else {
       std::vector<int64_t> perm = Arange(0, output_info[0].Rank());
@@ -282,21 +279,24 @@ void SoftMaxMapper::Opset13() {
     AddAttribute(node, "axis", static_cast<int64_t>(0));
     helper_->Squeeze(node->output(0), output_info[0].name, {0});
   } else {
-    auto node = helper_->MakeNode("Softmax", {input_info[0].name},
-                                  {output_info[0].name});
+    auto node = helper_->MakeNode(
+        "Softmax", {input_info[0].name}, {output_info[0].name});
     AddAttribute(node, "axis", axis);
   }
 }
 
 void BReluMapper::Opset7() {
   auto x_info = GetInput("X");
-  helper_->Clip(x_info[0].name, GetOutput("Out")[0].name, t_min_, t_max_,
+  helper_->Clip(x_info[0].name,
+                GetOutput("Out")[0].name,
+                t_min_,
+                t_max_,
                 x_info[0].dtype);
 }
 
 void EluMapper::Opset7() {
-  auto node = helper_->MakeNode("Elu", {GetInput("X")[0].name},
-                                {GetOutput("Out")[0].name});
+  auto node = helper_->MakeNode(
+      "Elu", {GetInput("X")[0].name}, {GetOutput("Out")[0].name});
   AddAttribute(node, "alpha", alpha_);
 }
 
@@ -311,24 +311,25 @@ int32_t MishMapper::GetMinOpsetVersion(bool verbose) {
 void MishMapper::Opset7() {
   auto input_info = GetInput("X");
   auto out_info = GetOutput("Out");
-  auto input = helper_->AutoCast(input_info[0].name, input_info[0].dtype,
-                                 P2ODataType::FP32);
+  auto input = helper_->AutoCast(
+      input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
   auto softplus = helper_->MakeNode("Softplus", {input})->output(0);
   auto tanh = helper_->MakeNode("Tanh", {softplus})->output(0);
   auto output = helper_->MakeNode("Mul", {input, tanh})->output(0);
-  helper_->AutoCast(output, out_info[0].name, P2ODataType::FP32,
-                    out_info[0].dtype);
+  helper_->AutoCast(
+      output, out_info[0].name, P2ODataType::FP32, out_info[0].dtype);
 }
 
 void SquareMapper::Opset7() {
   auto input_info = GetInput("X");
-  helper_->MakeNode("Mul", {input_info[0].name, input_info[0].name},
+  helper_->MakeNode("Mul",
+                    {input_info[0].name, input_info[0].name},
                     {GetOutput("Out")[0].name});
 }
 
 void SoftShrinkMapper::Opset9() {
-  auto node = helper_->MakeNode("Shrink", {GetInput("X")[0].name},
-                                {GetOutput("Out")[0].name});
+  auto node = helper_->MakeNode(
+      "Shrink", {GetInput("X")[0].name}, {GetOutput("Out")[0].name});
   AddAttribute(node, "lambd", lambda_);
   AddAttribute(node, "bias", lambda_);
 }
@@ -337,8 +338,8 @@ void SizeMapper::Opset7() {
   auto out_info = GetOutput("Out");
   auto output =
       helper_->MakeNode("Size", {GetInput("Input")[0].name})->output(0);
-  output = helper_->AutoCast(output, out_info[0].name, P2ODataType::INT64,
-                             out_info[0].dtype);
+  output = helper_->AutoCast(
+      output, out_info[0].name, P2ODataType::INT64, out_info[0].dtype);
 }
 
 void RsqrtMapper::Opset7() {
@@ -371,8 +372,8 @@ void LogSoftmaxMapper::Opset7() {
       axis += input_info[0].Rank();
     }
     if (axis == input_info[0].Rank() - 1) {
-      auto node = helper_->MakeNode("LogSoftmax", {input_info[0].name},
-                                    {GetOutput("Out")[0].name});
+      auto node = helper_->MakeNode(
+          "LogSoftmax", {input_info[0].name}, {GetOutput("Out")[0].name});
       AddAttribute(node, "axis", axis);
     } else {
       auto perm = Arange(0, input_info[0].Rank());
@@ -394,7 +395,9 @@ void ThresholdedReluMapper::Opset10() {
     input = helper_->AutoCast(input, x_info[0].dtype, P2ODataType::FP32);
     auto node = helper_->MakeNode("ThresholdedRelu", {input});
     AddAttribute(node, "alpha", threshold_);
-    helper_->AutoCast(node->output(0), out_info[0].name, P2ODataType::FP32,
+    helper_->AutoCast(node->output(0),
+                      out_info[0].name,
+                      P2ODataType::FP32,
                       out_info[0].dtype);
   } else {
     auto node =
@@ -406,9 +409,8 @@ void ThresholdedReluMapper::Opset10() {
 void Log1PMapper::Opset7() {
   auto x_info = GetInput("X");
   auto out_info = GetOutput("Out");
-  auto one = helper_->Constant({},
-                               GetOnnxDtype(x_info[0].dtype),
-                               static_cast<float>(1.0));
+  auto one = helper_->Constant(
+      {}, GetOnnxDtype(x_info[0].dtype), static_cast<float>(1.0));
   auto input = helper_->MakeNode("Add", {x_info[0].name, one})->output(0);
   helper_->MakeNode("Log", {input}, {out_info[0].name});
 }

--- a/paddle2onnx/mapper/activation/hardtanh.cc
+++ b/paddle2onnx/mapper/activation/hardtanh.cc
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle2onnx/mapper/activation/hardtanh.h"
+
+namespace paddle2onnx {
+REGISTER_PIR_MAPPER(hardtanh, HardtanhMapper)
+
+int32_t HardtanhMapper::GetMinOpsetVersion(bool verbose) {
+  Logger(verbose, 7) << RequireOpset(7) << std::endl;
+  return 7;
+}
+
+void HardtanhMapper::Opset7() {
+  auto input_info = GetInput("x");
+  auto output_info = GetOutput("out");
+
+  helper_->Clip(
+      input_info[0].name, output_info[0].name, min_, max_, input_info[0].dtype);
+}
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/activation/hardtanh.h
+++ b/paddle2onnx/mapper/activation/hardtanh.h
@@ -11,36 +11,36 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #pragma once
+
+#include <cmath>
+#include <map>
 #include <string>
 #include <vector>
 
 #include "paddle2onnx/mapper/mapper.h"
 
 namespace paddle2onnx {
-
-class EmptyMapper : public Mapper {
+class HardtanhMapper : public Mapper {
  public:
-  EmptyMapper(const PaddleParser& p,
-              OnnxHelper* helper,
-              int64_t block_id,
-              int64_t op_id)
-      : Mapper(p, helper, block_id, op_id) {
-    GetAttr("dtype", &output_dtype_);
-  }
-  EmptyMapper(const PaddlePirParser& p,
-              OnnxHelper* helper,
-              int64_t block_id,
-              int64_t op_id)
-      : Mapper(p, helper, block_id, op_id) {
-    GetAttr("dtype", &output_dtype_);
+  HardtanhMapper(const PaddlePirParser& p,
+                 OnnxHelper* helper,
+                 int64_t i,
+                 bool c)
+      : Mapper(p, helper, i, c) {
+    if (HasAttr("min")) {
+      GetAttr("min", &min_);
+    }
+    if (HasAttr("max")) {
+      GetAttr("max", &max_);
+    }
   }
 
   int32_t GetMinOpsetVersion(bool verbose) override;
-  void Opset11() override;
+  void Opset7() override;
 
  private:
-  int64_t output_dtype_;
+  float min_ = -1.0;
+  float max_ = 1.0;
 };
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/nn/pool2d.h
+++ b/paddle2onnx/mapper/nn/pool2d.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "paddle2onnx/mapper/exporter.h"
 #include "paddle2onnx/mapper/mapper.h"
 
 namespace paddle2onnx {
@@ -70,21 +71,22 @@ class Pool2dMapper : public Mapper {
     }
     GetAttr("strides", &strides_);
     GetAttr("paddings", &pads_);
-    // TODO: need double check
-    GetAttr("pooling_type", &pooling_type_);
-    GetAttr("data_format", &data_format_);
     GetAttr("ceil_mode", &ceil_mode_);
-    if (HasAttr("padding_algorithm")) {
-      GetAttr("padding_algorithm", &padding_algorithm_);
-    } else {
-      padding_algorithm_ = "EXPLICIT";
+    if (convert_pir_op_name(OpType()) != "max_pool2d_with_index") {
+      GetAttr("pooling_type", &pooling_type_);
+      GetAttr("data_format", &data_format_);
+      if (HasAttr("padding_algorithm")) {
+        GetAttr("padding_algorithm", &padding_algorithm_);
+      } else {
+        padding_algorithm_ = "EXPLICIT";
+      }
+      if (HasAttr("exclusive")) {
+        GetAttr("exclusive", &exclusive_);
+      } else {
+        exclusive_ = true;
+      }
+      exclusive_ = !exclusive_;
     }
-    if (HasAttr("exclusive")) {
-      GetAttr("exclusive", &exclusive_);
-    } else {
-      exclusive_ = true;
-    }
-    exclusive_ = !exclusive_;
   }
   int32_t GetMinOpsetVersion(bool verbose) override;
   void Opset7() override;

--- a/paddle2onnx/mapper/nn/pool3d.h
+++ b/paddle2onnx/mapper/nn/pool3d.h
@@ -16,14 +16,16 @@
 #include <string>
 #include <vector>
 
-#include "paddle2onnx/mapper/mapper.h"
 #include "paddle2onnx/mapper/exporter.h"
+#include "paddle2onnx/mapper/mapper.h"
 
 namespace paddle2onnx {
 
 class Pool3dMapper : public Mapper {
  public:
-  Pool3dMapper(const PaddleParser& p, OnnxHelper* helper, int64_t block_id,
+  Pool3dMapper(const PaddleParser& p,
+               OnnxHelper* helper,
+               int64_t block_id,
                int64_t op_id)
       : Mapper(p, helper, block_id, op_id) {
     op_mapper_["max"] = {"MaxPool", "GlobalMaxPool"};
@@ -43,9 +45,8 @@ class Pool3dMapper : public Mapper {
     }
   }
 
-  Pool3dMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i,
-                  bool c)
-      :Mapper(p, helper, i, c) {
+  Pool3dMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i, bool c)
+      : Mapper(p, helper, i, c) {
     op_mapper_["max"] = {"MaxPool", "GlobalMaxPool"};
     op_mapper_["avg"] = {"AveragePool", "GlobalAveragePool"};
     GetAttr("global_pooling", &global_pooling_);
@@ -53,10 +54,10 @@ class Pool3dMapper : public Mapper {
     GetAttr("strides", &strides_);
     GetAttr("paddings", &pads_);
     GetAttr("ksize", &k_size_);
+    GetAttr("ceil_mode", &ceil_mode_);
     if (convert_pir_op_name(OpType()) != "max_pool3d_with_index") {
       GetAttr("pooling_type", &pooling_type_);
       GetAttr("data_format", &data_format_);
-      GetAttr("ceil_mode", &ceil_mode_);
       GetAttr("padding_algorithm", &padding_algorithm_);
       GetAttr("exclusive", &exclusive_);
       exclusive_ = !exclusive_;
@@ -71,7 +72,8 @@ class Pool3dMapper : public Mapper {
                     const std::vector<TensorInfo>& output_info);
   void NoAdaptivePool(const std::vector<TensorInfo>& input_info,
                       const std::vector<TensorInfo>& output_info);
-  const std::unordered_set<int32_t> kNoNeedCastTypesOpSet7{P2ODataType::FP16, P2ODataType::FP32};
+  const std::unordered_set<int32_t> kNoNeedCastTypesOpSet7{P2ODataType::FP16,
+                                                           P2ODataType::FP32};
   bool ceil_mode_;
   bool global_pooling_;
   bool adaptive_;

--- a/paddle2onnx/mapper/nn/unfold.cc
+++ b/paddle2onnx/mapper/nn/unfold.cc
@@ -21,116 +21,153 @@ namespace paddle2onnx {
 REGISTER_MAPPER(unfold, UnfoldMapper)
 REGISTER_PIR_MAPPER(unfold, UnfoldMapper)
 int32_t UnfoldMapper::GetMinOpsetVersion(bool verbose) {
-    Logger(verbose, 11) << RequireOpset(11) << std::endl;
-    return 11;
+  Logger(verbose, 11) << RequireOpset(11) << std::endl;
+  return 11;
 }
 std::vector<int64_t> arange_(int64_t start, int64_t end, int64_t step) {
-    std::vector<int64_t> result;
-    for (int64_t i = start; i < end; i += step)
-    {
-        result.push_back(i);
-    }
-    return result;
+  std::vector<int64_t> result;
+  for (int64_t i = start; i < end; i += step) {
+    result.push_back(i);
+  }
+  return result;
 }
-std::vector<std::string> UnfoldMapper::_get_shape(std::string & x){
-    std::string nchw = helper_->MakeNode("Shape", {x})->output(0);
-    std::vector<std::string> nchw_vec = helper_->Split(nchw, {1,1,1,1}, 0);
-    for (int i=0;i<nchw_vec.size();i++){
-        nchw_vec[i] = helper_->Squeeze(nchw_vec[i], {});
-    }
-    return nchw_vec;
+std::vector<std::string> UnfoldMapper::_get_shape(std::string &x) {
+  std::string nchw = helper_->MakeNode("Shape", {x})->output(0);
+  std::vector<std::string> nchw_vec = helper_->Split(nchw, {1, 1, 1, 1}, 0);
+  for (int i = 0; i < nchw_vec.size(); i++) {
+    nchw_vec[i] = helper_->Squeeze(nchw_vec[i], {});
+  }
+  return nchw_vec;
 }
 void UnfoldMapper::Opset11() {
-    auto input_info = GetInput("X");
-    auto output_info = GetOutput("Y");
-    std::vector<std::string> nchw_vec = _get_shape(input_info[0].name);
-    std::string input_batch = nchw_vec[0];
-    std::string input_channel = nchw_vec[1];
-    std::string input_h = nchw_vec[2];
-    std::string input_w = nchw_vec[3];
-    Assert(
-        paddings_[0] == paddings_[2] && paddings_[1] == paddings_[3],
-        "paddings[0] is not equal to paddings[2]!");
+  auto input_info = GetInput("X");
+  auto output_info = GetOutput("Y");
+  std::vector<std::string> nchw_vec = _get_shape(input_info[0].name);
+  std::string input_batch = nchw_vec[0];
+  std::string input_channel = nchw_vec[1];
+  std::string input_h = nchw_vec[2];
+  std::string input_w = nchw_vec[3];
 
-    int64_t padding_h = paddings_[0], padding_w = paddings_[2];
-    int64_t kernel_h = kernel_sizes_[0], kernel_w = kernel_sizes_[1];
-    int64_t stride_h = strides_[0], stride_w = strides_[1];
-    int64_t dilation_h = dilations_[0], dilation_w = dilations_[1];
+  int64_t padding_h_start = paddings_[0], padding_h_end = paddings_[2];
+  int64_t padding_w_start = paddings_[1], padding_w_end = paddings_[3];
+  int64_t kernel_h = kernel_sizes_[0], kernel_w = kernel_sizes_[1];
+  int64_t stride_h = strides_[0], stride_w = strides_[1];
+  int64_t dilation_h = dilations_[0], dilation_w = dilations_[1];
 
-    std::string blocks_row_indices, blocks_col_indices, output_shape, padded_input;
+  std::string blocks_row_indices, blocks_col_indices, output_shape,
+      padded_input;
 
-    blocks_row_indices = _get_im2col_indices_along_dim(
-        input_h, kernel_h, dilation_h, padding_h, stride_h);
-    blocks_col_indices = _get_im2col_indices_along_dim(
-        input_w, kernel_w, dilation_w, padding_w, stride_w);
+  blocks_row_indices = _get_im2col_indices_along_dim(
+      input_h, kernel_h, dilation_h, padding_h_start, padding_h_end, stride_h);
+  blocks_col_indices = _get_im2col_indices_along_dim(
+      input_w, kernel_w, dilation_w, padding_w_start, padding_w_end, stride_w);
 
-    output_shape = _get_im2col_output_shape(input_batch, input_channel, kernel_h, kernel_w);
-    padded_input = _get_im2col_padded_input(input_info[0].name, padding_h, padding_w);
-    auto gather_node1 = helper_->MakeNode("Gather", {padded_input, blocks_row_indices});
-    AddAttribute(gather_node1, "axis", (int64_t)2);
-    auto gather_node2 = helper_->MakeNode("Gather", {gather_node1->output(0), blocks_col_indices});
-    AddAttribute(gather_node2, "axis", (int64_t)4);
+  output_shape =
+      _get_im2col_output_shape(input_batch, input_channel, kernel_h, kernel_w);
+  padded_input = _get_im2col_padded_input(input_info[0].name,
+                                          padding_h_start,
+                                          padding_h_end,
+                                          padding_w_start,
+                                          padding_w_end);
+  auto gather_node1 =
+      helper_->MakeNode("Gather", {padded_input, blocks_row_indices});
+  AddAttribute(gather_node1, "axis", (int64_t)2);
+  auto gather_node2 = helper_->MakeNode(
+      "Gather", {gather_node1->output(0), blocks_col_indices});
+  AddAttribute(gather_node2, "axis", (int64_t)4);
 
-    auto transpose_node = helper_->MakeNode("Transpose", {gather_node2->output(0)});
-    std::vector<int64_t> perm{0, 1, 2, 4, 3, 5};
-    AddAttribute(transpose_node, "perm", perm);
-    helper_->MakeNode("Reshape", {transpose_node->output(0), output_shape}, {output_info[0].name});
+  auto transpose_node =
+      helper_->MakeNode("Transpose", {gather_node2->output(0)});
+  std::vector<int64_t> perm{0, 1, 2, 4, 3, 5};
+  AddAttribute(transpose_node, "perm", perm);
+  helper_->MakeNode("Reshape",
+                    {transpose_node->output(0), output_shape},
+                    {output_info[0].name});
 }
 
 std::string UnfoldMapper::_get_im2col_indices_along_dim(std::string intput_d,
-          int64_t kernel_size_d, int64_t dialation_d, int64_t padding_d, int64_t stride_d){
+                                                        int64_t kernel_size_d,
+                                                        int64_t dialation_d,
+                                                        int64_t padding_start_d,
+                                                        int64_t padding_end_d,
+                                                        int64_t stride_d) {
+  std::string blocks_d, blocks_d_indices, kernel_grid, kernel_mask, block_mask;
+  blocks_d =
+      helper_
+          ->MakeNode("Add",
+                     {intput_d,
+                      helper_->Constant({},
+                                        ONNX_NAMESPACE::TensorProto::INT64,
+                                        padding_start_d + padding_end_d)})
+          ->output(0);
+  blocks_d =
+      helper_
+          ->MakeNode("Sub",
+                     {blocks_d,
+                      helper_->Constant({},
+                                        ONNX_NAMESPACE::TensorProto::INT64,
+                                        dialation_d * (kernel_size_d - 1))})
+          ->output(0);
+  blocks_d_indices =
+      helper_
+          ->MakeNode(
+              "Range",
+              {helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, 0),
+               blocks_d,
+               helper_->Constant(
+                   {}, ONNX_NAMESPACE::TensorProto::INT64, stride_d)})
+          ->output(0);
+  std::vector<int64_t> kernel_grid_vec =
+      arange_(0, kernel_size_d * dialation_d, dialation_d);
+  kernel_grid =
+      helper_->Constant({1, static_cast<int64_t>(kernel_grid_vec.size())},
+                        ONNX_NAMESPACE::TensorProto::INT64,
+                        kernel_grid_vec);
 
-    std::string blocks_d, blocks_d_indices, kernel_grid, kernel_mask, block_mask;
-    blocks_d = helper_->MakeNode(
-        "Add",
-        {intput_d,
-            helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, padding_d * 2)
-        })->output(0);
-    blocks_d = helper_->MakeNode(
-        "Sub",
-        {blocks_d,
-          helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, dialation_d * (kernel_size_d - 1))
-          })->output(0);
-    blocks_d_indices = helper_->MakeNode(
-        "Range",
-        {helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, 0),
-            blocks_d,
-            helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, stride_d)
-        })->output(0);
-        std::vector<int64_t> kernel_grid_vec = arange_(0, kernel_size_d * dialation_d, dialation_d);
-        kernel_grid = helper_->Constant({1, static_cast<int64_t>(kernel_grid_vec.size())}, ONNX_NAMESPACE::TensorProto::INT64, kernel_grid_vec);
+  blocks_d_indices = helper_->Unsqueeze(blocks_d_indices, {0});
+  kernel_mask = helper_->Reshape(kernel_grid, {-1, 1});
 
-        blocks_d_indices = helper_->Unsqueeze(blocks_d_indices, {0});
-        kernel_mask = helper_->Reshape(kernel_grid, {-1, 1});
-
-        block_mask = helper_->MakeNode("Add", {blocks_d_indices, kernel_mask})->output(0);
-        return block_mask;
+  block_mask =
+      helper_->MakeNode("Add", {blocks_d_indices, kernel_mask})->output(0);
+  return block_mask;
 }
-std::string UnfoldMapper::_get_im2col_padded_input(std::string & input_name, int64_t padding_h, int64_t padding_w){
-        std::vector<int64_t> pad_constant{0, 0, padding_h, padding_w, 0, 0, padding_h, padding_w};
-        std::string pad = helper_->Constant(
-            ONNX_NAMESPACE::TensorProto::INT64,
-            pad_constant
-        );
+std::string UnfoldMapper::_get_im2col_padded_input(std::string &input_name,
+                                                   int64_t padding_h_start,
+                                                   int64_t padding_h_end,
+                                                   int64_t padding_w_start,
+                                                   int64_t padding_w_end) {
+  std::vector<int64_t> pad_constant{0,
+                                    0,
+                                    padding_h_start,
+                                    padding_w_start,
+                                    0,
+                                    0,
+                                    padding_h_end,
+                                    padding_w_end};
+  std::string pad =
+      helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, pad_constant);
 
-        return helper_->MakeNode("Pad", {input_name, pad})->output(0);
+  return helper_->MakeNode("Pad", {input_name, pad})->output(0);
 }
-std::string UnfoldMapper::_get_im2col_output_shape(std::string &batch_dim, std::string &channel_dim, int64_t kernel_h, int64_t kernel_w){
-        std::string channel_unfolded = helper_->MakeNode(
-            "Mul",
-            {channel_dim,
-                helper_->Constant({}, ONNX_NAMESPACE::TensorProto::INT64, kernel_h * kernel_w)
-            }
-        )->output(0);
+std::string UnfoldMapper::_get_im2col_output_shape(std::string &batch_dim,
+                                                   std::string &channel_dim,
+                                                   int64_t kernel_h,
+                                                   int64_t kernel_w) {
+  std::string channel_unfolded =
+      helper_
+          ->MakeNode("Mul",
+                     {channel_dim,
+                      helper_->Constant({},
+                                        ONNX_NAMESPACE::TensorProto::INT64,
+                                        kernel_h * kernel_w)})
+          ->output(0);
 
-        auto concat_node = helper_->MakeNode(
-                "Concat",
-                {helper_->Unsqueeze(batch_dim, {0}),
-                    helper_->Unsqueeze(channel_unfolded, {0}),
-                    helper_->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64,-1)
-                }
-        );
-        AddAttribute(concat_node, "axis", (int64_t) 0);
-        return concat_node->output(0);
+  auto concat_node = helper_->MakeNode(
+      "Concat",
+      {helper_->Unsqueeze(batch_dim, {0}),
+       helper_->Unsqueeze(channel_unfolded, {0}),
+       helper_->Constant({1}, ONNX_NAMESPACE::TensorProto::INT64, -1)});
+  AddAttribute(concat_node, "axis", (int64_t)0);
+  return concat_node->output(0);
 }
-} // namespace paddle2onnx
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/nn/unfold.h
+++ b/paddle2onnx/mapper/nn/unfold.h
@@ -22,7 +22,9 @@ namespace paddle2onnx {
 
 class UnfoldMapper : public Mapper {
  public:
-  UnfoldMapper(const PaddleParser& p, OnnxHelper* helper, int64_t block_id,
+  UnfoldMapper(const PaddleParser& p,
+               OnnxHelper* helper,
+               int64_t block_id,
                int64_t op_id)
       : Mapper(p, helper, block_id, op_id) {
     GetAttr("dilations", &dilations_);
@@ -31,9 +33,8 @@ class UnfoldMapper : public Mapper {
     GetAttr("kernel_sizes", &kernel_sizes_);
   }
 
-  UnfoldMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i,
-                  bool c)
-      :Mapper(p, helper, i, c) {
+  UnfoldMapper(const PaddlePirParser& p, OnnxHelper* helper, int64_t i, bool c)
+      : Mapper(p, helper, i, c) {
     GetAttr("dilations", &dilations_);
     GetAttr("strides", &strides_);
     GetAttr("paddings", &paddings_);
@@ -42,10 +43,23 @@ class UnfoldMapper : public Mapper {
 
   int32_t GetMinOpsetVersion(bool verbose = false);
   void Opset11();
-  std::string _get_im2col_indices_along_dim(std::string intput_d, int64_t kernel_size_d, int64_t dialation_d,  int64_t padding_d, int64_t stride_d);
-  std::string _get_im2col_output_shape(std::string & batch_dim, std::string & channel_dim, int64_t kernel_h, int64_t kernel_w);
-  std::string _get_im2col_padded_input(std::string & input_name, int64_t padding_h, int64_t padding_w);
-  std::vector<std::string> _get_shape(std::string & x);
+  std::string _get_im2col_indices_along_dim(std::string intput_d,
+                                            int64_t kernel_size_d,
+                                            int64_t dialation_d,
+                                            int64_t padding_start_d,
+                                            int64_t padding_end_d,
+                                            int64_t stride_d);
+  std::string _get_im2col_output_shape(std::string& batch_dim,     // NOLINT
+                                       std::string& channel_dim,   // NOLINT
+                                       int64_t kernel_h,
+                                       int64_t kernel_w);
+  std::string _get_im2col_padded_input(std::string& input_name,    // NOLINT
+                                       int64_t padding_h_start,
+                                       int64_t padding_h_end,
+                                       int64_t padding_w_start,
+                                       int64_t padding_w_end);
+  std::vector<std::string> _get_shape(std::string& x);             // NOLINT
+
  private:
   std::vector<int64_t> dilations_;
   std::vector<int64_t> strides_;

--- a/paddle2onnx/mapper/tensor/empty.cc
+++ b/paddle2onnx/mapper/tensor/empty.cc
@@ -1,93 +1,103 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "paddle2onnx/mapper/tensor/empty.h"
 
-namespace paddle2onnx
-{
-  REGISTER_MAPPER(empty, EmptyMapper)
+namespace paddle2onnx {
+REGISTER_MAPPER(empty, EmptyMapper)
+REGISTER_PIR_MAPPER(empty, EmptyMapper)
 
-  int32_t EmptyMapper::GetMinOpsetVersion(bool verbose)
-  {
-    constexpr int op_version = 11;
-    Logger(verbose, op_version) << RequireOpset(op_version) << std::endl;
-    return op_version;
+int32_t EmptyMapper::GetMinOpsetVersion(bool verbose) {
+  constexpr int op_version = 11;
+  Logger(verbose, op_version) << RequireOpset(op_version) << std::endl;
+  return op_version;
+}
+
+void EmptyMapper::Opset11() {
+  std::vector<TensorInfo> out_info = GetOutput("Out");
+  // shape tensor/tensor list/tuple
+  bool shape_is_tensor = HasInput("ShapeTensor");
+  bool shape_is_tensor_list = HasInput("ShapeTensorList");
+  bool shape_is_other_types = !(shape_is_tensor || shape_is_tensor_list);
+  // Paddle-model output dtype to onnx-model dtype
+  ONNX_NAMESPACE::TensorProto_DataType onnx_dtype =
+      GetOnnxDtype(out_info[0].dtype);
+  // Fill with 0
+  float value = 0;
+  // a) If shape is list or tuple (that means it's not a variable), we can use
+  // constant op directly
+  if (shape_is_other_types) {
+    std::vector<int64_t> shape;
+    GetAttr("shape", &shape);
+    helper_->Constant(
+        out_info[0].name,
+        shape,
+        onnx_dtype,
+        value);  // The acceptable (shape) argument must be vector<int64_t>
+    return;
   }
-
-  void EmptyMapper::Opset11()
-  {
-    std::vector<TensorInfo> out_info = GetOutput("Out");
-    // shape tensor/tensor list/tuple
-    bool shape_is_tensor = HasInput("ShapeTensor");
-    bool shape_is_tensor_list = HasInput("ShapeTensorList");
-    bool shape_is_other_types = !(shape_is_tensor || shape_is_tensor_list);
-    // Paddle-model output dtype to onnx-model dtype
-    ONNX_NAMESPACE::TensorProto_DataType onnx_dtype = GetOnnxDtype(out_info[0].dtype);
-    // Fill with 0
-    float value = 0;
-    // a) If shape is list or tuple (that means it's not a variable), we can use constant op directly
-    if (shape_is_other_types)
-    {
-      std::vector<int64_t> shape;
-      GetAttr("shape", &shape);
-      helper_->Constant(out_info[0].name, shape, onnx_dtype, value);// The acceptable (shape) argument must be vector<int64_t> 
-      return;
-    }
-    // b) If shape is tensor (variable), we should cast them to INT64.
-    // c) If shape is tensorlist (variable), we should cast them to INT64 and concat all tensors (the ConcatIndices function has implemented the cast).
-    std::string shape_name;
-    if (shape_is_tensor)
-    {
-      std::vector<TensorInfo> shape_info = GetInput("ShapeTensor");
-      shape_name = helper_->AutoCast(shape_info[0].name, shape_info[0].dtype, P2ODataType::INT64);
-    }
-    else //tensor list
-    {
-      std::vector<TensorInfo> shape_info = GetInput("ShapeTensorList");
-      shape_name = helper_->ConcatIndices(shape_info);
-    }
-    auto node = helper_->MakeNode("ConstantOfShape", {shape_name}, {out_info[0].name});
-
-    // The attribute [value] of ConstantOfShape op, a one-element tensor, is the value filled in output.
-    auto attr = node->add_attribute();
-    attr->set_name("value");                                // attribute name
-    attr->set_type(ONNX_NAMESPACE::AttributeProto::TENSOR); // attribute dtype
-    auto tensor = attr->mutable_t();
-    tensor->set_name(out_info[0].name);
-    tensor->set_data_type(onnx_dtype);                      // onnx dytpe, not a paddle dtype
-    tensor->add_dims(1);                                    // one dimension tensor with one element
-    if (onnx_dtype == ONNX_NAMESPACE::TensorProto::INT32)
-    {
-      std::vector<int32_t> data(1);
-      data[0] = static_cast<int32_t>(value);
-      const char *ptr = reinterpret_cast<const char *>(data.data());
-      tensor->set_raw_data(std::string(ptr, sizeof(int32_t)));
-    }
-    else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::INT64)
-    {
-      std::vector<int64_t> data(1);
-      data[0] = static_cast<int64_t>(value);
-      const char *ptr = reinterpret_cast<const char *>(data.data());
-      tensor->set_raw_data(std::string(ptr, sizeof(int64_t)));
-    }
-    else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::FLOAT)
-    {
-      std::vector<float> data(1, value); // float do not need to be converted.
-      const char *ptr = reinterpret_cast<const char *>(data.data());
-      tensor->set_raw_data(std::string(ptr, sizeof(float)));
-    }
-    else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::DOUBLE)
-    {
-      std::vector<double> data(1);
-      data[0] = static_cast<double>(value);
-      const char *ptr = reinterpret_cast<const char *>(data.data());
-      tensor->set_raw_data(std::string(ptr, sizeof(double)));
-    }
-    else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::BOOL)
-    {
-      // std::vector<bool> is a specialized container class that stores data not as a byte per Boolean value, but as a bit compression.
-      // This makes the direct use of std::vector<bool> potentially problematic
-      bool *data = new bool[1];
-      data[0] = static_cast<bool>(value);
-      tensor->set_raw_data(std::string((const char *)(data), sizeof(bool)));
-      delete[] data;
-    }
+  // b) If shape is tensor (variable), we should cast them to INT64.
+  // c) If shape is tensorlist (variable), we should cast them to INT64 and
+  // concat all tensors (the ConcatIndices function has implemented the cast).
+  std::string shape_name;
+  if (shape_is_tensor) {
+    std::vector<TensorInfo> shape_info = GetInput("ShapeTensor");
+    shape_name = helper_->AutoCast(
+        shape_info[0].name, shape_info[0].dtype, P2ODataType::INT64);
+  } else {  // tensor list
+    std::vector<TensorInfo> shape_info = GetInput("ShapeTensorList");
+    shape_name = helper_->ConcatIndices(shape_info);
   }
-} // namespace paddle2onnx
+  auto node =
+      helper_->MakeNode("ConstantOfShape", {shape_name}, {out_info[0].name});
+
+  // The attribute [value] of ConstantOfShape op, a one-element tensor, is the
+  // value filled in output.
+  auto attr = node->add_attribute();
+  attr->set_name("value");                                 // attribute name
+  attr->set_type(ONNX_NAMESPACE::AttributeProto::TENSOR);  // attribute dtype
+  auto tensor = attr->mutable_t();
+  tensor->set_name(out_info[0].name);
+  tensor->set_data_type(onnx_dtype);  // onnx dytpe, not a paddle dtype
+  tensor->add_dims(1);                // one dimension tensor with one element
+  if (onnx_dtype == ONNX_NAMESPACE::TensorProto::INT32) {
+    std::vector<int32_t> data(1);
+    data[0] = static_cast<int32_t>(value);
+    const char *ptr = reinterpret_cast<const char *>(data.data());
+    tensor->set_raw_data(std::string(ptr, sizeof(int32_t)));
+  } else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::INT64) {
+    std::vector<int64_t> data(1);
+    data[0] = static_cast<int64_t>(value);
+    const char *ptr = reinterpret_cast<const char *>(data.data());
+    tensor->set_raw_data(std::string(ptr, sizeof(int64_t)));
+  } else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::FLOAT) {
+    std::vector<float> data(1, value);  // float do not need to be converted.
+    const char *ptr = reinterpret_cast<const char *>(data.data());
+    tensor->set_raw_data(std::string(ptr, sizeof(float)));
+  } else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::DOUBLE) {
+    std::vector<double> data(1);
+    data[0] = static_cast<double>(value);
+    const char *ptr = reinterpret_cast<const char *>(data.data());
+    tensor->set_raw_data(std::string(ptr, sizeof(double)));
+  } else if (onnx_dtype == ONNX_NAMESPACE::TensorProto::BOOL) {
+    // std::vector<bool> is a specialized container class that stores data not
+    // as a byte per Boolean value, but as a bit compression. This makes the
+    // direct use of std::vector<bool> potentially problematic
+    bool *data = new bool[1];
+    data[0] = static_cast<bool>(value);
+    tensor->set_raw_data(std::string((const char *)(data), sizeof(bool)));
+    delete[] data;
+  }
+}
+}  // namespace paddle2onnx

--- a/paddle2onnx/mappers_registry.h.in
+++ b/paddle2onnx/mappers_registry.h.in
@@ -214,5 +214,8 @@ USE_P2O_MAPPER(isinf, IsInfMapper)
 USE_P2O_MAPPER(isnan, IsNaNMapper)
 USE_P2O_MAPPER(isfinite, Isfiniteapper)
 USE_P2O_MAPPER(masked_select, MaskedSelectMapper)
+USE_P2O_MAPPER(uniform, UniformMapper)
+USE_P2O_MAPPER(conv3d_transpose, Conv3dTransposeMapper)
+USE_P2O_MAPPER(hardtanh, HardtanhMapper)
 #endif // WITH_PADDLE2ONNX_STATIC_INTERNAL_AT_COMPILING
 #endif // WITH_PADDLE2ONNX_STATIC_INTERNAL

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -35,7 +35,6 @@ set ignore=test_auto_scan_multiclass_nms.py
 set ignore=!ignore! test_auto_scan_roi_align.py
 set ignore=!ignore! test_auto_scan_pool_adaptive_max_ops.py
 set ignore=!ignore! test_auto_scan_pad2d.py
-set ignore=!ignore! test_auto_scan_unfold.py
 set ignore=!ignore! test_auto_scan_uniform_random_batch_size_like.py
 set ignore=!ignore! test_auto_scan_uniform_random.py
 set ignore=!ignore! test_auto_scan_distribute_fpn_proposals1.py
@@ -50,7 +49,6 @@ set ignore=!ignore! test_quantize_model.py
 set ignore=!ignore! test_quantize_model_minist.py
 set ignore=!ignore! test_quantize_model_speedup.py
 set ignore=!ignore! test_resnet_fp16.py
-set ignore=!ignore! test_empty.py
 set ignore=!ignore! test_auto_scan_pool_max_ops.py
 set ignore=!ignore! test_auto_scan_fill_constant.py
 set ignore=!ignore! test_auto_scan_layer_norm.py
@@ -65,7 +63,6 @@ set ignore=!ignore! test_auto_scan_grid_sampler.py
 set ignore=!ignore! test_auto_scan_dequantize_linear.py
 set ignore=!ignore! test_auto_scan_gaussian_random.py
 set ignore=!ignore! test_auto_scan_partial_ops.py
-set ignore=!ignore! test_auto_scan_unary_ops.py
 
 REM Initialize bug count
 set bug=0

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -49,7 +49,6 @@ set ignore=!ignore! test_quantize_model.py
 set ignore=!ignore! test_quantize_model_minist.py
 set ignore=!ignore! test_quantize_model_speedup.py
 set ignore=!ignore! test_resnet_fp16.py
-set ignore=!ignore! test_auto_scan_pool_max_ops.py
 set ignore=!ignore! test_auto_scan_fill_constant.py
 set ignore=!ignore! test_auto_scan_layer_norm.py
 set ignore=!ignore! test_auto_scan_scatter_nd_add.py

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,18 +29,15 @@ ignore="test_auto_scan_multiclass_nms.py
         test_auto_scan_roi_align.py \ # need to be rewrite
         test_auto_scan_pool_adaptive_max_ops.py \
         test_auto_scan_pad2d.py \
-        test_auto_scan_unfold.py \
         test_auto_scan_uniform_random_batch_size_like.py \
         test_auto_scan_uniform_random.py \
         test_auto_scan_gaussian_random.py \
         test_auto_scan_distribute_fpn_proposals1.py \
         test_auto_scan_distribute_fpn_proposals_v2.py \
         test_auto_scan_fill_constant_batch_size_like.py \
-        test_auto_scan_unary_ops.py \
         test_auto_scan_generate_proposals.py \
         test_uniform.py \
         test_deform_conv2d.py \
-        test_hardtanh.py \
         test_nn_GRU.py \
         test_quantize_model.py \
         test_quantize_model_minist.py \
@@ -50,7 +47,6 @@ ignore="test_auto_scan_multiclass_nms.py
         test_auto_scan_quantize_linear.py \
         test_quantize_model_speedup.py \
         test_resnet_fp16.py \
-        test_empty.py \
         test_auto_scan_pool_max_ops.py \
         test_auto_scan_fill_constant.py"
 bug=0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,7 +47,6 @@ ignore="test_auto_scan_multiclass_nms.py
         test_auto_scan_quantize_linear.py \
         test_quantize_model_speedup.py \
         test_resnet_fp16.py \
-        test_auto_scan_pool_max_ops.py \
         test_auto_scan_fill_constant.py"
 bug=0
 

--- a/tests/test_auto_scan_pool_max_ops.py
+++ b/tests/test_auto_scan_pool_max_ops.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from auto_scan_test import OPConvertAutoScanTest, BaseNet
-from hypothesis import reproduce_failure
 import hypothesis.strategies as st
 import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class NetMaxpool1d(BaseNet):
@@ -29,18 +29,19 @@ class NetMaxpool1d(BaseNet):
         """
         forward
         """
-        kernel_size = self.config['kernel_size']
-        stride = self.config['stride']
-        padding = self.config['padding']
-        ceil_mode = self.config['ceil_mode']
-        return_mask = self.config['return_mask']
+        kernel_size = self.config["kernel_size"]
+        stride = self.config["stride"]
+        padding = self.config["padding"]
+        ceil_mode = self.config["ceil_mode"]
+        return_mask = self.config["return_mask"]
         x = paddle.nn.functional.max_pool1d(
             inputs,
             kernel_size=kernel_size,
             stride=stride,
             padding=padding,
             return_mask=return_mask,
-            ceil_mode=ceil_mode)
+            ceil_mode=ceil_mode,
+        )
         if return_mask:
             return x[0]
         return x
@@ -54,9 +55,8 @@ class TestMaxpool1dConvert(OPConvertAutoScanTest):
 
     def sample_convert_config(self, draw):
         input_shape = draw(
-            st.lists(
-                st.integers(
-                    min_value=10, max_value=20), min_size=3, max_size=3))
+            st.lists(st.integers(min_value=10, max_value=20), min_size=3, max_size=3)
+        )
 
         # input_shape = [3, 1, 10]
         dtype = draw(st.sampled_from(["float32", "float64"]))
@@ -70,22 +70,16 @@ class TestMaxpool1dConvert(OPConvertAutoScanTest):
             kernel_size = draw(st.integers(min_value=7, max_value=10))
         elif kernel_type == "list":
             kernel_size = draw(
-                st.lists(
-                    st.integers(
-                        min_value=7, max_value=10),
-                    min_size=1,
-                    max_size=1))
+                st.lists(st.integers(min_value=7, max_value=10), min_size=1, max_size=1)
+            )
 
         stride_type = draw(st.sampled_from(["None", "int", "list"]))
         if stride_type == "int":
             stride = draw(st.integers(min_value=1, max_value=5))
         elif stride_type == "list":
             stride = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=1,
-                    max_size=1))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=1)
+            )
         else:
             stride = None
 
@@ -101,9 +95,9 @@ class TestMaxpool1dConvert(OPConvertAutoScanTest):
         if padding == "VALID":
             ceil_mode = False
         if return_mask:
-            op_names = 'max_pool2d_with_index'
+            op_names = "max_pool2d_with_index"
         else:
-            op_names = 'pool2d'
+            op_names = "pool2d"
 
         config = {
             "op_names": [op_names],
@@ -122,6 +116,7 @@ class TestMaxpool1dConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 
@@ -135,12 +130,12 @@ class NetMaxpool2d(BaseNet):
         """
         forward
         """
-        kernel_size = self.config['kernel_size']
-        stride = self.config['stride']
-        padding = self.config['padding']
-        return_mask = self.config['return_mask']
-        ceil_mode = self.config['ceil_mode']
-        data_format = self.config['data_format']
+        kernel_size = self.config["kernel_size"]
+        stride = self.config["stride"]
+        padding = self.config["padding"]
+        return_mask = self.config["return_mask"]
+        ceil_mode = self.config["ceil_mode"]
+        data_format = self.config["data_format"]
         x = paddle.nn.functional.max_pool2d(
             inputs,
             kernel_size=kernel_size,
@@ -148,7 +143,8 @@ class NetMaxpool2d(BaseNet):
             padding=padding,
             return_mask=return_mask,
             ceil_mode=ceil_mode,
-            data_format=data_format)
+            data_format=data_format,
+        )
         if return_mask:
             return x[0]
         return x
@@ -162,9 +158,8 @@ class TestMaxpool2dConvert(OPConvertAutoScanTest):
 
     def sample_convert_config(self, draw):
         input_shape = draw(
-            st.lists(
-                st.integers(
-                    min_value=10, max_value=20), min_size=4, max_size=4))
+            st.lists(st.integers(min_value=10, max_value=20), min_size=4, max_size=4)
+        )
 
         dtype = draw(st.sampled_from(["float32", "float64"]))
         data_format = draw(st.sampled_from(["NCHW"]))
@@ -179,64 +174,59 @@ class TestMaxpool2dConvert(OPConvertAutoScanTest):
             kernel_size = draw(st.integers(min_value=7, max_value=10))
         elif kernel_type == "list":
             kernel_size = draw(
-                st.lists(
-                    st.integers(
-                        min_value=7, max_value=10),
-                    min_size=2,
-                    max_size=2))
+                st.lists(st.integers(min_value=7, max_value=10), min_size=2, max_size=2)
+            )
 
         stride_type = draw(st.sampled_from(["None", "int", "list"]))
         if stride_type == "int":
             stride = draw(st.integers(min_value=1, max_value=5))
         elif stride_type == "list":
             stride = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=2,
-                    max_size=2))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=2, max_size=2)
+            )
         else:
             stride = None
 
         padding_type = draw(
-            st.sampled_from(["None", "str", "int", "list2", "list4", "list8"]))
+            st.sampled_from(["None", "str", "int", "list2", "list4", "list8"])
+        )
         if padding_type == "str":
             padding = draw(st.sampled_from(["SAME", "VALID"]))
         elif padding_type == "int":
             padding = draw(st.integers(min_value=1, max_value=5))
         elif padding_type == "list2":
             padding = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=2,
-                    max_size=2))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=2, max_size=2)
+            )
         elif padding_type == "list4":
             padding = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=4,
-                    max_size=4))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=4, max_size=4)
+            )
         elif padding_type == "list8":
             padding1 = np.expand_dims(
                 np.array(
                     draw(
                         st.lists(
-                            st.integers(
-                                min_value=1, max_value=5),
+                            st.integers(min_value=1, max_value=5),
                             min_size=2,
-                            max_size=2))),
-                axis=0).tolist()
+                            max_size=2,
+                        )
+                    )
+                ),
+                axis=0,
+            ).tolist()
             padding2 = np.expand_dims(
                 np.array(
                     draw(
                         st.lists(
-                            st.integers(
-                                min_value=1, max_value=5),
+                            st.integers(min_value=1, max_value=5),
                             min_size=2,
-                            max_size=2))),
-                axis=0).tolist()
+                            max_size=2,
+                        )
+                    )
+                ),
+                axis=0,
+            ).tolist()
             if data_format == "NCHW":
                 padding = [[0, 0]] + [[0, 0]] + padding1 + padding2
             else:
@@ -257,9 +247,9 @@ class TestMaxpool2dConvert(OPConvertAutoScanTest):
         if padding == "VALID":
             ceil_mode = False
         if return_mask:
-            op_names = 'max_pool2d_with_index'
+            op_names = "max_pool2d_with_index"
         else:
-            op_names = 'pool2d'
+            op_names = "pool2d"
         config = {
             "op_names": [op_names],
             "test_data_shapes": [input_shape],
@@ -271,13 +261,14 @@ class TestMaxpool2dConvert(OPConvertAutoScanTest):
             "padding": padding,
             "return_mask": return_mask,
             "ceil_mode": ceil_mode,
-            "data_format": data_format
+            "data_format": data_format,
         }
 
         models = NetMaxpool2d(config)
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 
@@ -291,12 +282,12 @@ class NetMaxpool3d(BaseNet):
         """
         forward
         """
-        kernel_size = self.config['kernel_size']
-        stride = self.config['stride']
-        padding = self.config['padding']
-        ceil_mode = self.config['ceil_mode']
-        return_mask = self.config['return_mask']
-        data_format = self.config['data_format']
+        kernel_size = self.config["kernel_size"]
+        stride = self.config["stride"]
+        padding = self.config["padding"]
+        ceil_mode = self.config["ceil_mode"]
+        return_mask = self.config["return_mask"]
+        data_format = self.config["data_format"]
         x = paddle.nn.functional.max_pool3d(
             inputs,
             kernel_size=kernel_size,
@@ -304,7 +295,8 @@ class NetMaxpool3d(BaseNet):
             padding=padding,
             return_mask=return_mask,
             ceil_mode=ceil_mode,
-            data_format=data_format)
+            data_format=data_format,
+        )
         if return_mask:
             return x[0]
         return x
@@ -313,15 +305,14 @@ class NetMaxpool3d(BaseNet):
 ## TODO max_pool3d_with_index not support yet
 class TestMaxpool3dConvert(OPConvertAutoScanTest):
     """
-   api: paddle.nn.functional.max_pool3d
-   OPset version: 7, 9, 15
-   """
+    api: paddle.nn.functional.max_pool3d
+    OPset version: 7, 9, 15
+    """
 
     def sample_convert_config(self, draw):
         input_shape = draw(
-            st.lists(
-                st.integers(
-                    min_value=10, max_value=20), min_size=5, max_size=5))
+            st.lists(st.integers(min_value=10, max_value=20), min_size=5, max_size=5)
+        )
 
         dtype = draw(st.sampled_from(["float32", "float64"]))
         data_format = draw(st.sampled_from(["NCDHW"]))
@@ -335,73 +326,71 @@ class TestMaxpool3dConvert(OPConvertAutoScanTest):
             kernel_size = draw(st.integers(min_value=7, max_value=10))
         elif kernel_type == "list":
             kernel_size = draw(
-                st.lists(
-                    st.integers(
-                        min_value=7, max_value=10),
-                    min_size=3,
-                    max_size=3))
+                st.lists(st.integers(min_value=7, max_value=10), min_size=3, max_size=3)
+            )
 
         stride_type = draw(st.sampled_from(["None", "int", "list"]))
         if stride_type == "int":
             stride = draw(st.integers(min_value=1, max_value=5))
         elif stride_type == "list":
             stride = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=3,
-                    max_size=3))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=3, max_size=3)
+            )
         else:
             stride = None
 
         padding_type = draw(
-            st.sampled_from(["None", "str", "int", "list3", "list6", "list10"]))
+            st.sampled_from(["None", "str", "int", "list3", "list6", "list10"])
+        )
         if padding_type == "str":
             padding = draw(st.sampled_from(["SAME", "VALID"]))
         elif padding_type == "int":
             padding = draw(st.integers(min_value=1, max_value=5))
         elif padding_type == "list3":
             padding = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=3,
-                    max_size=3))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=3, max_size=3)
+            )
         elif padding_type == "list6":
             padding = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=6,
-                    max_size=6))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=6, max_size=6)
+            )
         elif padding_type == "list10":
             padding1 = np.expand_dims(
                 np.array(
                     draw(
                         st.lists(
-                            st.integers(
-                                min_value=1, max_value=5),
+                            st.integers(min_value=1, max_value=5),
                             min_size=2,
-                            max_size=2))),
-                axis=0).tolist()
+                            max_size=2,
+                        )
+                    )
+                ),
+                axis=0,
+            ).tolist()
             padding2 = np.expand_dims(
                 np.array(
                     draw(
                         st.lists(
-                            st.integers(
-                                min_value=1, max_value=5),
+                            st.integers(min_value=1, max_value=5),
                             min_size=2,
-                            max_size=2))),
-                axis=0).tolist()
+                            max_size=2,
+                        )
+                    )
+                ),
+                axis=0,
+            ).tolist()
             padding3 = np.expand_dims(
                 np.array(
                     draw(
                         st.lists(
-                            st.integers(
-                                min_value=1, max_value=5),
+                            st.integers(min_value=1, max_value=5),
                             min_size=2,
-                            max_size=2))),
-                axis=0).tolist()
+                            max_size=2,
+                        )
+                    )
+                ),
+                axis=0,
+            ).tolist()
             if data_format == "NCDHW":
                 padding = [[0, 0]] + [[0, 0]] + padding1 + padding2 + padding3
             else:
@@ -422,9 +411,9 @@ class TestMaxpool3dConvert(OPConvertAutoScanTest):
         if padding == "VALID":
             ceil_mode = False
         if return_mask:
-            op_names = 'max_pool3d_with_index'
+            op_names = "max_pool3d_with_index"
         else:
-            op_names = 'pool3d'
+            op_names = "pool3d"
 
         config = {
             "op_names": [op_names],
@@ -444,6 +433,7 @@ class TestMaxpool3dConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_set_value.py
+++ b/tests/test_auto_scan_set_value.py
@@ -16,7 +16,7 @@ from auto_scan_test import OPConvertAutoScanTest, BaseNet
 import hypothesis.strategies as st
 import unittest
 import copy
-from onnxbase import _test_only_pir
+from onnxbase import _test_with_pir
 
 
 # TODO(wangmingkai02): add test for set_value which none_axes_ > 0
@@ -55,14 +55,14 @@ class TestSetValueConvert(OPConvertAutoScanTest):
             "test_data_shapes": [input_shape, update_input_shape],
             "test_data_types": [[dtype], [dtype]],
             "opset_version": [17, 19],
-            "input_spec_shape": [],
+            "input_spec_shape": [input_shape, update_input_shape],
         }
 
         models = Net(config)
 
         return (config, models)
 
-    @_test_only_pir
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=30)
 

--- a/tests/test_auto_scan_unary_ops.py
+++ b/tests/test_auto_scan_unary_ops.py
@@ -65,7 +65,7 @@ opset_version_map = {
     "exp": [7, 13, 15],
     "floor": [7, 13, 15],
     "hard_shrink": [9, 15],
-    "brelu": [9, 15],
+    # "brelu": [9, 15],
     "log": [7, 13, 15],
     "log1p": [7, 13, 14, 15],
     "log2": [7, 13, 15],

--- a/tests/test_auto_scan_unfold.py
+++ b/tests/test_auto_scan_unfold.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 from auto_scan_test import OPConvertAutoScanTest, BaseNet
-from hypothesis import reproduce_failure
 import hypothesis.strategies as st
-import numpy as np
 import unittest
 import paddle
+from onnxbase import _test_with_pir
 
 
 class Net(BaseNet):
@@ -34,7 +33,8 @@ class Net(BaseNet):
             self.config["kernel_size"],
             strides=self.config["strides"],
             paddings=self.config["paddings"],
-            dilations=self.config["dilations"])
+            dilations=self.config["dilations"],
+        )
         return x
 
 
@@ -46,45 +46,35 @@ class TestUnfoldConvert(OPConvertAutoScanTest):
 
     def sample_convert_config(self, draw):
         input_shape = draw(
-            st.lists(
-                st.integers(
-                    min_value=20, max_value=30), min_size=4, max_size=4))
+            st.lists(st.integers(min_value=20, max_value=30), min_size=4, max_size=4)
+        )
 
         kernel_size = draw(
-            st.lists(
-                st.integers(
-                    min_value=1, max_value=5), min_size=1, max_size=2))
+            st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=2)
+        )
         if len(kernel_size) == 1:
             kernel_size = kernel_size[0]
 
         strides = draw(
-            st.lists(
-                st.integers(
-                    min_value=1, max_value=5), min_size=1, max_size=2))
+            st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=2)
+        )
         if len(strides) == 1:
             strides = strides[0]
 
         if draw(st.booleans()):
             paddings = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=1,
-                    max_size=2))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=1, max_size=2)
+            )
             if len(paddings) == 1:
                 paddings = paddings[0]
         else:
             paddings = draw(
-                st.lists(
-                    st.integers(
-                        min_value=1, max_value=5),
-                    min_size=4,
-                    max_size=4))
+                st.lists(st.integers(min_value=1, max_value=5), min_size=4, max_size=4)
+            )
 
         dilations = draw(
-            st.lists(
-                st.integers(
-                    min_value=1, max_value=3), min_size=1, max_size=2))
+            st.lists(st.integers(min_value=1, max_value=3), min_size=1, max_size=2)
+        )
 
         if len(dilations) == 1:
             dilations = dilations[0]
@@ -112,6 +102,7 @@ class TestUnfoldConvert(OPConvertAutoScanTest):
 
         return (config, models)
 
+    @_test_with_pir
     def test(self):
         self.run_and_statis(max_examples=25)
 

--- a/tests/test_empty.py
+++ b/tests/test_empty.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import paddle
-from onnxbase import APIOnnx
-from onnxbase import randtool
+from onnxbase import APIOnnx, _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -30,10 +29,12 @@ class Net(paddle.nn.Layer):
         forward
         """
         x = paddle.empty(shape, dtype=paddle.int64)
-        print(x)
+        x = paddle.zeros_like(x)
+
         return x
 
 
+@_test_with_pir
 def test_empty_11():
     """
     api: paddle.empty
@@ -42,8 +43,7 @@ def test_empty_11():
     op = Net()
     op.eval()
     # net, name, ver_list, delta=1e-6, rtol=1e-5
-    obj = APIOnnx(op, 'empty', [11])
-    shape = paddle.to_tensor([4,6], dtype=paddle.int64)
-    print(shape)
+    obj = APIOnnx(op, "empty", [11])
+    shape = paddle.to_tensor([4, 6], dtype=paddle.int64)
     obj.set_input_data("input_data", shape)
     obj.run()

--- a/tests/test_hardtanh.py
+++ b/tests/test_hardtanh.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import paddle
-from onnxbase import APIOnnx
-from onnxbase import randtool
+from onnxbase import APIOnnx, randtool, _test_with_pir
 
 
 class Net(paddle.nn.Layer):
@@ -33,6 +32,7 @@ class Net(paddle.nn.Layer):
         return x
 
 
+@_test_with_pir
 def test_hardtanh_9():
     """
     api: paddle.hardtanh
@@ -49,6 +49,7 @@ def test_hardtanh_9():
     obj.run()
 
 
+@_test_with_pir
 def test_hardtanh_10():
     """
     api: paddle.hardtanh
@@ -65,6 +66,7 @@ def test_hardtanh_10():
     obj.run()
 
 
+@_test_with_pir
 def test_hardtanh_11():
     """
     api: paddle.hardtanh
@@ -81,6 +83,7 @@ def test_hardtanh_11():
     obj.run()
 
 
+@_test_with_pir
 def test_hardtanh_12():
     """
     api: paddle.hardtanh


### PR DESCRIPTION
支持 hardtanh 并修复 unfold, empty, max_pool2d_with_index, max_pool3d_with_index
1.新增 HardtanhMapper。
2. unfold 中增加不对称 paddling 的支持。
3. empty 算子中元素值是未初始化的，因此单测使用 zeros_like 统一输出结果。
4. 修复 Pool2dMapper 中的 pd_op.max_pool2d_with_index 情况和 Pool3dMapper 中的 pd_op.max_pool3d_with_index 情况，在pir中这两个算子的kernel_size当做attr传入。