### PR TITLE
Support PP-FormulaNet-S and PP-FormulaNet-L

### DIFF
--- a/paddle2onnx/mapper/tensor/full_with_tensor.cc
+++ b/paddle2onnx/mapper/tensor/full_with_tensor.cc
@@ -31,6 +31,10 @@ void FullWithTensorMapper::Opset8() {
   auto shape = helper_->AutoCast(
       shape_info[0].name, shape_info[0].dtype, P2ODataType::INT64);
 
+  if (shape_info[0].Rank() == 0) {
+    shape = helper_->Reshape(shape, {1});
+  }
+
   auto expand_node = helper_->MakeNode("Expand", {value_info[0].name, shape});
 
   helper_->AutoCast(expand_node->output(0),

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -107,11 +107,15 @@ std::string PaddlePirParser::GetOpOutputName(const pir::Value& source) const {
 
 std::string PaddlePirParser::GetSubBlockOpOutputName(
     const pir::Value& source) const {
-  auto it = while_op_values_args_map.find(&(*(source.impl())));
+  auto name_iter = while_op_args_name_map.find(&(*(source.impl())));
+  if (name_iter != while_op_args_name_map.end()) {
+    return name_iter->second;
+  }
+  auto value_iter = while_op_values_args_map.find(&(*(source.impl())));
   pir::Operation* op;
   uint32_t output_idx;
-  if (it != while_op_values_args_map.end()) {
-    pir::Value value(it->second);
+  if (value_iter != while_op_values_args_map.end()) {
+    pir::Value value(value_iter->second);
     op = value.defining_op();
     output_idx = value.dyn_cast<pir::OpResult>().index();
   } else {

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -45,6 +45,8 @@ class PaddlePirParser {
   // recording args of while op body name info
   mutable std::unordered_map<pir::detail::ValueImpl*, pir::detail::ValueImpl*>
       while_op_values_args_map;
+  mutable std::unordered_map<pir::detail::ValueImpl*, std::string>
+      while_op_args_name_map;
   int NumOfBlocks() const;
   // int NumOfOps(int block_idx) const;
   int NumOfProgramOps() const;


### PR DESCRIPTION
### 修复PP-FormulaNet-S and PP-FormulaNet-L的转化和推理问题
#### 转化失败问题
```bash
1. Error in checking the ONNX model './inference.onnx': Graph must be in single static assignment (SSA) form, however 'p2o.pd_op.scale.0.0' has been used as graph input names multiple times.
```
* 分析：pd_op.while算子输入中包含重复的同一变量，比如变量%1124在PP-FormulaNet-S中的pd_op.while的输入中出现了两次
* 修复：为重复变量增加一个Identity，构造一个新的变量作为输入
```bash
2. This is an invalid model. Subgraph output (p2o.pd_op.transpose.0.0) is an outer scope value being returned directly. Please update the model to add an Identity node between the outer scope value and the subgraph output.
```
* 分析：pd_op.while block中的yield的输入存在pd_op.while block之外的变量
* 修复：在loop子图中增加一个Identity用来连接外部变量和loop子图中的变量

#### 推理失败问题
```bash
1. [ONNXRuntimeError] : 1 : FAIL : Load model from ./inference.onnx failed:Node (Expand.2) Op (Expand) [ShapeInferenceError] shape input must be 1D tensor
```
* 分析：算子full_with_tensor的输入shape可能是个标量，需要先转换为tensor后再传入Expand
* 修复：对于标量先进行reshape
```bash
2. /opt/rh/gcc-toolset-12/root/usr/include/c++/12/bits/stl_vector.h:1123: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = onnx::TypeProto; _Alloc = std::allocator<onnx::TypeProto>; reference = onnx::TypeProto&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```
* 分析：控制流问题，当while block中的yield的输入存在while block之外的变量时，处理策略是将外部的变量传入传入到onnx的loop以及loop子图的输入输出中，导致的这个问题
* 修复：直接在loop子图中增加一个Identity用来连接外部变量和loop子图中的变量
```bash
3. Non-zero status code returned while running Add node. Name:'Add.32' Status Message: /onnxruntime_src/onnxruntime/core/providers/cpu/math/element_wise_ops.h:540 void onnxruntime::BroadcastIterator::Init(ptrdiff_t, ptrdiff_t) axis == 1 || axis == largest was false. Attempting to broadcast an axis by a dimension other than 1. 3 by 6
```
* 分析：在修复转化问题1时，只是修改了loop以及其子block中输入的名字，但是在控制流中，存在args，对于args变量去找定义它的变量时还是会找到原来的变量，而不是我们通过Identity构造的新的变量
* 修复：在pir_parser中新增while_op_args_name_map，记录上述情况的args和Identity产生的变量名字的映射关系，查找变量时优先检查while_op_args_name_map