### PR TITLE
Fix the issue with batch norm op exposed in LaTeX_OCR_rec

### DIFF
--- a/paddle2onnx/mapper/nn/batch_norm.cc
+++ b/paddle2onnx/mapper/nn/batch_norm.cc
@@ -21,6 +21,14 @@ namespace paddle2onnx {
 REGISTER_MAPPER(batch_norm, BatchNormMapper)
 REGISTER_PIR_MAPPER(batch_norm, BatchNormMapper)
 
+int32_t BatchNormMapper::GetMinOpsetVersion(bool verbose) {
+  if(!use_global_stats_) {
+    Logger(verbose, 14) << RequireOpset(14) << std::endl;
+    return 14;
+  }
+  return 7;
+}
+
 void BatchNormMapper::Opset7() {
   auto input_info = GetInput("X");
   auto mean_info = GetInput("Mean");
@@ -62,6 +70,58 @@ void BatchNormMapper::Opset7() {
 
   AddAttribute(node, "epsilon", epsilon_);
   AddAttribute(node, "momentum", momentum_);
+}
+
+void BatchNormMapper::Opset14() {
+  auto input_info = GetInput("X");
+  auto mean_info = GetInput("Mean");
+  auto variance_info = GetInput("Variance");
+  auto output_info = GetOutput("Y");
+  auto mean_out_info = GetOutput("MeanOut");
+  auto variance_out_info = GetOutput("VarianceOut");
+
+  std::string scale_name, bias_name;
+  int64_t numel = 1;
+  for (auto s : mean_info[0].shape) {
+    numel *= s;
+  }
+  if (HasInput("Scale")) {
+    scale_name = GetInput("Scale")[0].name;
+  } else {
+    std::vector<int64_t> values(numel, 1);
+    scale_name = helper_->Constant(
+        mean_info[0].shape, GetOnnxDtype(mean_info[0].dtype), values);
+  }
+
+  if (HasInput("Bias")) {
+    bias_name = GetInput("Bias")[0].name;
+  } else {
+    std::vector<int64_t> values(numel, 0);
+    bias_name = helper_->Constant(
+        mean_info[0].shape, GetOnnxDtype(mean_info[0].dtype), values);
+  }
+
+  std::vector<std::string> output_names;
+  output_names.push_back(output_info[0].name);
+  if (!use_global_stats_) {
+    output_names.push_back(mean_out_info[0].name);
+    output_names.push_back(variance_out_info[0].name);
+  }
+  auto node = helper_->MakeNode("BatchNormalization",
+                                {input_info[0].name,
+                                 scale_name,
+                                 bias_name,
+                                 mean_info[0].name,
+                                 variance_info[0].name},
+                                 output_names);
+  if (helper_->GetOpsetVersion() < 9) {
+    int64_t spatial = 1;
+    AddAttribute(node, "spatial", spatial);
+  }
+
+  AddAttribute(node, "epsilon", epsilon_);
+  AddAttribute(node, "momentum", momentum_);
+  AddAttribute(node, "training_mode", static_cast<int64_t>(!use_global_stats_));
 }
 
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/nn/batch_norm.h
+++ b/paddle2onnx/mapper/nn/batch_norm.h
@@ -29,6 +29,7 @@ class BatchNormMapper : public Mapper {
       : Mapper(p, helper, block_id, op_id) {
     GetAttr("epsilon", &epsilon_);
     GetAttr("momentum", &momentum_);
+    GetAttr("use_global_stats", &use_global_stats_);
   }
 
   BatchNormMapper(const PaddlePirParser& p,
@@ -44,7 +45,9 @@ class BatchNormMapper : public Mapper {
     GetAttr("data_format", &data_format_);
   }
 
+  int32_t GetMinOpsetVersion(bool verbose) override;
   void Opset7() override;
+  void Opset14() override;
 
  private:
   bool is_test_;

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -69,7 +69,8 @@ set bug=0
 REM Install Python packages
 set PY_CMD=%1
 %PY_CMD% -m pip install pytest
-%PY_CMD% -m pip install onnx onnxruntime tqdm filelock
+%PY_CMD% -m pip install tqdm filelock
+%PY_CMD% -m pip install onnx==1.16.0 onnxruntime==1.20.1
 %PY_CMD% -m pip install six hypothesis
 REM %PY_CMD% -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
 %PY_CMD% -m pip install https://paddle2onnx.bj.bcebos.com/paddle_windows/paddlepaddle_gpu-0.0.0-cp310-cp310-win_amd64.whl

--- a/tests/test_auto_scan_batch_norm.py
+++ b/tests/test_auto_scan_batch_norm.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from auto_scan_test import OPConvertAutoScanTest, BaseNet
-from hypothesis import reproduce_failure
 import hypothesis.strategies as st
-import numpy as np
 import unittest
 import paddle
 from paddle import ParamAttr
@@ -29,35 +27,39 @@ class Net(BaseNet):
 
     def __init__(self, config=None):
         super(Net, self).__init__(config)
-        if self.config['data_format'] in ["NC", "NCL", "NCHW", "NCDHW", "NCHW"]:
-            param_shape = [self.config['input_shape'][1]]
+        if self.config["data_format"] in ["NC", "NCL", "NCHW", "NCDHW", "NCHW"]:
+            param_shape = [self.config["input_shape"][1]]
         else:
-            param_shape = [self.config['input_shape'][-1]]
-        dtype = self.config['dtype']
+            param_shape = [self.config["input_shape"][-1]]
+        dtype = self.config["dtype"]
 
         self.mean = self.create_parameter(
             dtype=dtype,
             attr=ParamAttr(
                 initializer=paddle.nn.initializer.Constant(0.0),
                 trainable=False,
-                do_model_average=True),
-            shape=param_shape)
+                do_model_average=True,
+            ),
+            shape=param_shape,
+        )
 
         self.variance = self.create_parameter(
             dtype=dtype,
             attr=ParamAttr(
                 initializer=paddle.nn.initializer.Constant(1.0),
                 trainable=False,
-                do_model_average=True),
-            shape=param_shape)
+                do_model_average=True,
+            ),
+            shape=param_shape,
+        )
 
         self.weight = self.create_parameter(
             shape=param_shape,
             dtype=dtype,
-            default_initializer=paddle.nn.initializer.Constant(1.0))
+            default_initializer=paddle.nn.initializer.Constant(1.0),
+        )
 
-        self.bias = self.create_parameter(
-            shape=param_shape, dtype=dtype, is_bias=True)
+        self.bias = self.create_parameter(shape=param_shape, dtype=dtype, is_bias=True)
 
     def forward(self, inputs):
         """
@@ -69,10 +71,11 @@ class Net(BaseNet):
             running_var=self.variance,
             weight=self.weight,
             bias=self.bias,
-            momentum=self.config['momentum'],
-            epsilon=self.config['epsilon'],
-            data_format=self.config['data_format'],
-            use_global_stats=self.config['use_global_stats'])
+            momentum=self.config["momentum"],
+            epsilon=self.config["epsilon"],
+            data_format=self.config["data_format"],
+            use_global_stats=self.config["use_global_stats"],
+        )
         return x
 
 
@@ -84,11 +87,9 @@ class TestBatchNormConvert(OPConvertAutoScanTest):
 
     def sample_convert_config(self, draw):
         input_shape = draw(
-            st.lists(
-                st.integers(
-                    min_value=4, max_value=8), min_size=2, max_size=5))
+            st.lists(st.integers(min_value=4, max_value=8), min_size=2, max_size=5)
+        )
 
-        input_spec = [-1] * len(input_shape)
         dtype = draw(st.sampled_from(["float32", "float64"]))
         epsilon = draw(st.floats(min_value=1e-12, max_value=1e-5))
         momentum = draw(st.floats(min_value=0.1, max_value=0.9))
@@ -103,7 +104,7 @@ class TestBatchNormConvert(OPConvertAutoScanTest):
         use_global_stats = None
         is_use_global_stats = draw(st.sampled_from(["None", "False", "True"]))
         if is_use_global_stats == "False":
-            use_global_stats = None  # has a diff
+            use_global_stats = False
         elif is_use_global_stats == "True":
             use_global_stats = True
 
@@ -111,7 +112,7 @@ class TestBatchNormConvert(OPConvertAutoScanTest):
             "op_names": ["batch_norm"],
             "test_data_shapes": [input_shape],
             "test_data_types": [[dtype]],
-            "opset_version": [7, 9, 15],
+            "opset_version": [7, 9] if use_global_stats else [14, 15],
             "input_spec_shape": [],
             "epsilon": epsilon,
             "momentum": momentum,


### PR DESCRIPTION
Fix the issue with batch norm op exposed in LaTeX_OCR_rec

**Note:**
1. The unit test `test_auto_scan_pool_avg_ops.py` produces incorrect results with `onnxruntime==1.21.0` on the Windows platform. However, there are no issues when the ORT version is downgraded to `1.20.1` which is same with our local env.
2. Following errors occurred when upgrading onnx to 1.17.0 or onnxruntime to 1.21.0 at our local env
![image](https://github.com/user-attachments/assets/36540744-1b84-4cd9-90a1-921cec84c6ad)
