### PR TITLE
[CI] Fix the issue with action on push

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,8 +23,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 1000
-      # Merge target branch
-      - name: Merge ${{ github.event.pull_request.base.ref }} branch
+      # Merge base branch
+      - name: Merge base branch
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge origin/${{ github.event.pull_request.base.ref }}
@@ -66,8 +67,9 @@ jobs:
           submodules: true
           fetch-depth: 1000
 
-      # Merge target branch
-      - name: Merge ${{ github.event.pull_request.base.ref }} branch
+      # Merge base branch
+      - name: Merge base branch
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge origin/${{ github.event.pull_request.base.ref }}
@@ -136,8 +138,9 @@ jobs:
           submodules: true
           fetch-depth: 1000
 
-      # Merge target branch
-      - name: Merge ${{ github.event.pull_request.base.ref }} branch
+      # Merge base branch
+      - name: Merge base branch
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge origin/${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
The `github.event.pull_request.base.ref` is empty string when github.event is not `pull_request`.
And it is not necessary to merge target develop when action event is `push`.