### PR TITLE
[PIR] A new rule for input and output names.

### DIFF
--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -214,7 +214,7 @@ int32_t ModelExporter::GetCfBlockMinOpsetVersion(
   }
   // Must generate All sub_block's op output names must be generated here
   // because it's may used in OPMapper.GetMinOpsetVersion function.
-  pir_parser.GetAllSubBlockOpOutputName(pir_parser.sub_blocks_ops);
+  pir_parser.GetSubBlockOpOutputName(pir_parser.sub_blocks_ops);
   auto max_opset = GetMinOpsetVersion(pir_parser, &block, true);
   pir_parser.sub_blocks_ops.clear();
   pir_parser.sub_blocks_ops = sub_blocks_ops_copy;
@@ -477,7 +477,7 @@ ONNX_NAMESPACE::GraphProto ModelExporter::ExportIfBlock(
     }
   }
   // generate sub-block op outputs names in GetMinOpSetVersion() function.
-  // pir_parser.GetAllSubBlockOpOutputName(pir_parser.sub_blocks_ops);
+  // pir_parser.GetSubBlockOpOutputName(pir_parser.sub_blocks_ops);
   if (!pir_parser.sub_blocks_ops.empty()) {
     // get cf.yield op input
     pir::Operation* cf_yield_op = pir_parser.sub_blocks_ops.back();

--- a/paddle2onnx/mapper/while.cc
+++ b/paddle2onnx/mapper/while.cc
@@ -52,7 +52,7 @@ void ModelExporter::ExportWhile(PaddlePirParser& pir_parser,
   }
 
   // generate sub-block op outputs names in GetMinOpSetVersion() function.
-  // pir_parser.GetAllSubBlockOpOutputName(pir_parser.sub_blocks_ops);
+  // pir_parser.GetSubBlockOpOutputName(pir_parser.sub_blocks_ops);
   if (!pir_parser.sub_blocks_ops.empty()) {
     // get cf.yeild op input
     pir::Operation* cf_yield_op = pir_parser.sub_blocks_ops.back();

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "paddle/common/ddim.h"
@@ -129,7 +130,7 @@ std::string PaddlePirParser::GetSubBlockOpOutputName(
   return _op_outputs[op][output_idx];
 }
 
-void PaddlePirParser::GetAllSubBlockOpOutputName(
+void PaddlePirParser::GetSubBlockOpOutputName(
     std::vector<pir::Operation*> block_op_lists) const {
   for (auto op : block_op_lists) {
     std::string new_name = "p2o.sub_block." + op->name();
@@ -149,22 +150,22 @@ void PaddlePirParser::GetAllSubBlockOpOutputName(
     }
   }
 }
-void PaddlePirParser::GetAllOpOutputName() {
+void PaddlePirParser::GetGlobalBlockOpOutputName() {
   inputs.clear();
   outputs.clear();
   for (auto op : global_blocks_ops) {
     if (op->name() == "pd_op.data" || op->name() == "pd_op.feed") {
       std::string input_name =
           op->attribute<pir::StrAttribute>("name").AsString();
-      std::string var_name =
-          input_name + "." + GenOpInputOutputName(op->name());
-      inputs.push_back(GetTensorInfo(var_name, op->result(0).type()));
-      AddOpOutputName(op, var_name, 0);
+      inputs.push_back(GetTensorInfo(input_name, op->result(0).type()));
+      AddOpOutputName(op, input_name, 0);
     } else if (op->name() == "pd_op.fetch") {
+      std::string output_name =
+          op->attribute<pir::StrAttribute>("name").AsString();
+      outputs.push_back(GetTensorInfo(output_name, op->result(0).type()));
       auto value = op->operand(0).source();
       auto output_idx = value.dyn_cast<pir::OpResult>().index();
-      std::string var_name = _op_outputs[value.defining_op()][output_idx];
-      outputs.push_back(GetTensorInfo(var_name, op->result(0).type()));
+      AddOpOutputName(value.defining_op(), output_name, output_idx);
     } else {
       std::string var_name = GenOpInputOutputName(op->name());
       int num_outputs = op->num_results();
@@ -445,7 +446,7 @@ bool PaddlePirParser::Init(const std::string& _model,
 
   // InitBlock();
   GetGlobalBlocksOps();
-  GetAllOpOutputName();
+  GetGlobalBlockOpOutputName();
   GetOpArgNameMappings();
   GetAllBlocksOpsSet(pir_program_->block());
   return true;

--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -150,21 +150,58 @@ void PaddlePirParser::GetSubBlockOpOutputName(
     }
   }
 }
+
 void PaddlePirParser::GetGlobalBlockOpOutputName() {
+  /**
+   * Input names must be the same as those in the Paddle Model.
+   * However, output names may be changed in cases where an output name
+   * is the same as one of the input names and other operations exist.
+   *
+   * The new name's format is: {original name}.p2o.pd_op.fetch.{idx}
+   *
+   * Examples:
+   * 1. The following case, which can be reproduced in `test_while`
+   *    will change the output names.
+   * {
+   *   (%0) = "pd_op.feed" () {col:1,name:"0", ...} : () -> ...
+   *   (%1) = "pd_op.full" () {...} : () -> ...
+   *   (%3) = "pd_op.less_equal" (%1, %2) {...} : ... -> ...
+   *   (%4) = "pd_op.fetch" (%3) {col:0,name:"1", ...} : ... -> ...
+   * }
+   * 2. The following case, which can be reproduced in `test_auto_scan_dropout`
+   *    will not change the output names.
+   * {
+   *   (%0) = "pd_op.data" () {dtype:float32,name:"0", ...} () -> ...
+   *   (%1) = "pd_op.fetch" (%0) {col:0,name:"0", ...} : ... -> ...
+   * }
+   */
   inputs.clear();
   outputs.clear();
+  // determine whether to generate new name for outputs
+  std::unordered_set<std::string> input_names;
   for (auto op : global_blocks_ops) {
     if (op->name() == "pd_op.data" || op->name() == "pd_op.feed") {
       std::string input_name =
           op->attribute<pir::StrAttribute>("name").AsString();
       inputs.push_back(GetTensorInfo(input_name, op->result(0).type()));
       AddOpOutputName(op, input_name, 0);
+      input_names.insert(input_name);
     } else if (op->name() == "pd_op.fetch") {
-      std::string output_name =
+      std::string var_name =
           op->attribute<pir::StrAttribute>("name").AsString();
-      outputs.push_back(GetTensorInfo(output_name, op->result(0).type()));
+      std::string output_name;
       auto value = op->operand(0).source();
+      std::string def_op_name = value.defining_op()->name();
+      if (input_names.count(var_name) && def_op_name != "pd_op.data" &&
+          def_op_name != "pd_op.feed") {
+        output_name = var_name + "." + GenOpInputOutputName(op->name());
+      } else {
+        output_name = var_name;
+      }
       auto output_idx = value.dyn_cast<pir::OpResult>().index();
+      outputs.push_back(GetTensorInfo(output_name, op->result(0).type()));
+      // It's not necessary add output name of fetch op, but need to modify it's
+      // defining op here.
       AddOpOutputName(value.defining_op(), output_name, output_idx);
     } else {
       std::string var_name = GenOpInputOutputName(op->name());

--- a/paddle2onnx/parser/pir_parser.h
+++ b/paddle2onnx/parser/pir_parser.h
@@ -114,7 +114,7 @@ class PaddlePirParser {
                                    std::string name,
                                    bool is_input,
                                    bool if_in_subblock) const;
-  void GetAllSubBlockOpOutputName(
+  void GetSubBlockOpOutputName(
       std::vector<pir::Operation*> block_op_lists) const;
 
   bool IsConstantTensor(int64_t op_id,
@@ -288,7 +288,7 @@ class PaddlePirParser {
   void GetGlobalBlockInputOutputInfo();
   void GetGlobalBlockInputValueName();
   void GetGlobalBlockOutputValueName();
-  void GetAllOpOutputName();
+  void GetGlobalBlockOpOutputName();
   void AddOpOutputName(pir::Operation* op,
                        std::string var_name,
                        int64_t output_idx) const;

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -284,7 +284,6 @@ class APIOnnx(object):
                     self.input_feed[str(i)] = in_data.numpy()
 
                 i += 1
-        self.input_feed_backup = self.input_feed
 
     def set_device_mode(self, is_gpu=True):
         if paddle.device.is_compiled_with_cuda() is True and is_gpu:
@@ -353,10 +352,6 @@ class APIOnnx(object):
         """
         make onnx res
         """
-
-        def _get_origin_name(ort_input):
-            return ort_input.name.split(".")[0]
-
         model_path = os.path.join(
             self.pwd, self.name, self.name + "_" + str(ver) + ".onnx"
         )
@@ -365,13 +360,6 @@ class APIOnnx(object):
             model_path,
             providers=["CPUExecutionProvider"],
         )
-        origin_input_names = list(map(_get_origin_name, sess.get_inputs()))
-        temp_dict = {}
-        self.input_feed = self.input_feed_backup
-        for idx, name in enumerate(origin_input_names):
-            temp_dict[sess.get_inputs()[idx].name] = self.input_feed[name]
-        self.input_feed = temp_dict
-
         input_feed = {}
         if len(model.graph.input) == 0:
             return sess.run(output_names=None, input_feed=input_feed)


### PR DESCRIPTION
### Rule
Input names must be the same as those in the Paddle Model.However, output names may be changed in cases where an output name is the same as one of the input names and other operations exist.
### Examples:
   1. The following case, which can be reproduced in `test_while` will change the output names.
```
{
    (%0) = "pd_op.feed" () {col:1,name:"1",persistable:[false],stop_gradient:[false]} : () -> tensor<i64>
    (%1) = "pd_op.feed" () {col:0,name:"0",persistable:[false],stop_gradient:[false]} : () -> tensor<i64>
    (%2) = "pd_op.full" () {dtype:int64,persistable:[false],place:Place(undefined:0),shape:[],stop_gradient:[false],value:3} : () -> tensor<i64>
    (%3) = "pd_op.less_equal" (%1, %2) {persistable:[false],stop_gradient:[false]} : (tensor<i64>, tensor<i64>) -> tensor<b>
    (%4, %5) = "pd_op.while" (cond=%3, inputs=%1, %0) { 
    ^%arg_0 {}, %arg_1 {}
        (%6) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
        (%7) = "pd_op.scale" (%arg_0, %6) {bias:1,bias_after_scale:true} : (tensor<i64>, tensor<1xf32>) -> tensor<i64>
        (%8) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[1],stop_gradient:[true],value:1} : () -> tensor<1xf32>
        (%9) = "pd_op.scale" (%arg_1, %8) {bias:1,bias_after_scale:true} : (tensor<i64>, tensor<1xf32>) -> tensor<i64>
        (%10) = "pd_op.full" () {dtype:int64,place:Place(undefined:0),shape:[],value:3} : () -> tensor<i64>
        (%11) = "pd_op.less_equal" (%7, %10) {} : (tensor<i64>, tensor<i64>) -> tensor<b>
        (%12) = "pd_op.assign_out_" (%7, %arg_0) {} : (tensor<i64>, tensor<i64>) -> tensor<i64>
        (%13) = "pd_op.assign_out_" (%9, %arg_1) {} : (tensor<i64>, tensor<i64>) -> tensor<i64>
        (%14) = "pd_op.assign_out_" (%11, %3) {} : (tensor<b>, tensor<b>) -> tensor<b>
        () = "cf.yield" (%14, %12, %13) {} : (tensor<b>, tensor<i64>, tensor<i64>) -> 
    }
    (%15) = "pd_op.fetch" (%5) {col:0,name:"1"} : (tensor<i64>) -> tensor<i64>
}
```

   2. The following case, which can be reproduced in `test_auto_scan_dropout` will not change the output names.
```
{
    (%0) = "pd_op.data" () {dtype:float32,name:"0",place:Place(undefined:0),shape:[8],stop_gradient:[false]} : () -> tensor<8xf32>
    (%1) = "pd_op.fetch" (%0) {col:0,name:"0",persistable:[true],stop_gradient:[false]} : (tensor<8xf32>) -> tensor<8xf32>
}
```
### The new name's format
{original name}.p2o.pd_op.fetch.{idx}