### PR TITLE
[Fix] Fix the issue with split op and update ONNX optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ paddle2onnx --model_dir model_dir \
 | --enable_auto_update_opset | **[可选]** 是否开启opset version自动升级功能，当低版本opset无法转换时，自动选择更高版本的opset进行转换， 默认为 True          |
 | --enable_onnx_checker      | **[可选]** 配置是否检查导出为 ONNX 模型的正确性, 建议打开此开关， 默认为 True                                             |
 | --enable_dist_prim_all     | **[可选]** 是否开启组合算子拆解，默为 False                                                                           |
-| --enable_optimization      | **[可选]** 是否开启模型优化，默认为 True                                                                             |
+| --optimize_tool            | **[可选]** ONNX模型优化工具，可选择onnxoptimizer、polygraphy、None, 默认为 onnxoptimizer                              |
 | --enable_verbose           | **[可选]** 是否打印更更详细的日志信息，默认为 False                                                                    |
 | --version                  | **[可选]** 查看 paddle2onnx 版本                                                                                   |
 

--- a/README_en.md
+++ b/README_en.md
@@ -57,8 +57,8 @@ The adjustable conversion parameters are listed in the following table:
 | --opset_version            | **[Optional]** Configure the OpSet version converted to ONNX, currently supports multiple versions such as 7~19, the default is 9                                                                                                 |
 | --enable_auto_update_opset | **[Optional]** Whether to enable the opset version automatic upgrade function, when the lower version of the opset cannot be converted, automatically select the higher version of the opset for conversion, the default is True  |
 | --enable_onnx_checker      | **[Optional]** Configure whether to check the correctness of the exported ONNX model, it is recommended to turn on this switch, the default is True                                                                              |
-| --enable_dist_prim_all      | **[Optional]** Whether to enable the decomposition of combined operators, the default is False
-| --enable_optimization      | **[Optional]** Whether to enable onnx optimization, the default is True |
+| --enable_dist_prim_all     | **[Optional]** Whether to enable the decomposition of combined operators, the default is False
+| --optimize_tool            | **[Optional]** ONNX model optimization tool, options: onnxoptimizer, polygraphy, or None, the default is onnxoptimizer.
 | --enable_verbose           | **[Optional]** Whether to show verbose logs, default False |
 | --version                  | **[Optional]** View paddle2onnx version       |
 ### 4.4 Pruning ONNX

--- a/paddle2onnx/command.py
+++ b/paddle2onnx/command.py
@@ -103,11 +103,18 @@ def arg_parser():
     #     default="{}",
     #     help='Ops that needs to be converted to custom op, e.g --custom_ops \'{"paddle_op":"onnx_op"}\', default {}',
     # )
+    # parser.add_argument(
+    #     "--enable_optimization",
+    #     type=ast.literal_eval,
+    #     default=True,
+    #     help="whether enable onnx optimization, default True",
+    # )
     parser.add_argument(
-        "--enable_optimization",
-        type=ast.literal_eval,
-        default=True,
-        help="whether enable onnx optimization, default True",
+        "--optimize_tool",
+        type=str,
+        default="onnxoptimizer",
+        choices=["onnxoptimizer", "polygraphy", "None"],
+        help="onnx optimization tool, default onnxoptimizer",
     )
     parser.add_argument(
         "--enable_verbose",
@@ -180,7 +187,7 @@ def main():
         calibration_file="",
         external_file="",
         export_fp16_model=False,
-        enable_polygraphy=args.enable_optimization,
+        optimize_tool=args.optimize_tool,
     )
 
 

--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -135,7 +135,7 @@ def export(
     calibration_file="",
     external_file="",
     export_fp16_model=False,
-    enable_polygraphy=True,
+    optimize_tool="onnxoptimizer",
 ):
     global PADDLE2ONNX_EXPORT_TEMP_DIR
     # check model_filename
@@ -261,7 +261,51 @@ def export(
             PADDLE2ONNX_EXPORT_TEMP_DIR = None
 
     if save_file is not None:
-        if enable_polygraphy:
+        # if optimize_tool == "onnxsim":
+        #     try:
+        #         logging.info(
+        #             "Try to perform optimization on the ONNX model with Onnx Simplifier."
+        #         )
+        #         import io
+        #         import onnx
+        #         from onnxsim import simplify
+        #         model_stream = io.BytesIO(onnx_model_str)
+        #         onnx_model = onnx.load_model(model_stream)
+        #         simplified_model, check = simplify(onnx_model)
+        #         if check:
+        #             onnx.save(simplified_model, save_file)
+        #         else:
+        #             logging.warning(f"Fail to simplify onnx model. Skip simplifying.")
+        #     except Exception as error:
+        #         logging.warning(
+        #             f"Fail to simplify onnx model with error: {error}. Skip simplifying."
+        #         )
+        #         with open(save_file, "wb") as f:
+        #             f.write(onnx_model_str)
+        if optimize_tool == "onnxoptimizer":
+            try:
+                logging.info(
+                    "Try to perform optimization on the ONNX model with onnxoptimizer."
+                )
+                import io
+                import onnx
+                import onnxoptimizer
+
+                model_stream = io.BytesIO(onnx_model_str)
+                onnx_model = onnx.load_model(model_stream)
+                passes = [
+                    "eliminate_deadend",
+                    "eliminate_identity",
+                ]
+                optimized_model = onnxoptimizer.optimize(onnx_model, passes)
+                onnx.save(optimized_model, save_file)
+            except Exception as error:
+                logging.warning(
+                    f"Fail to optimize onnx model with error: {error}. Skip onnxoptimizer."
+                )
+                with open(save_file, "wb") as f:
+                    f.write(onnx_model_str)
+        elif optimize_tool == "polygraphy":
             try:
                 logging.info(
                     "Try to perform constant folding on the ONNX model with Polygraphy."

--- a/paddle2onnx/mapper/tensor/split.cc
+++ b/paddle2onnx/mapper/tensor/split.cc
@@ -99,10 +99,9 @@ std::string SplitMapper::GetSections(int64_t dimension) {
   if (HasInput("SectionsTensorList")) {
     auto info = GetInput("SectionsTensorList");
     splits = helper_->ConcatIndices(info);
-  } else if (HasInput("sections")) {
-    auto info = GetInput("sections");
-    splits = helper_->ConcatIndices(info);
-  } else if (sections_.size() > 0) {
+  } else if (sections_.size() > 0 ||
+             (HasInput("sections") &&
+              TryGetInputValue("sections", &sections_))) {
     int sum_of_known_dim = 0;
     for (size_t i = 0; i < sections_.size(); ++i) {
       if (sections_[i] > 0) {
@@ -118,6 +117,9 @@ std::string SplitMapper::GetSections(int64_t dimension) {
       }
     }
     splits = helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, sections_);
+  } else if (HasInput("sections")) {
+    auto info = GetInput("sections");
+    splits = helper_->ConcatIndices(info);
   } else if (HasAttr("num")) {
     GetAttr("num", &num_);
     Assert(dimension > 0,

--- a/paddle2onnx/mapper/tensor/split.cc
+++ b/paddle2onnx/mapper/tensor/split.cc
@@ -25,8 +25,13 @@ int32_t SplitMapper::GetMinOpsetVersion(bool verbose) {
     if (in_pir_mode) {
       double value = 0;
       std::string attr_name = "AxisTensor";
-      if (HasInput("axis")) attr_name = "axis";
-      TryGetInputValue(attr_name, &value);
+      if (HasInput("axis")) {
+        attr_name = "axis";
+      }
+      std::string err_msg = "While " + attr_name +
+                            " as the input and it's not a constant tensor, the "
+                            "conversion is not supported yet.";
+      Assert(TryGetInputValue(attr_name, &value), err_msg);
       axis = (int64_t)value;
     } else {
       std::vector<int64_t> value;
@@ -41,9 +46,7 @@ int32_t SplitMapper::GetMinOpsetVersion(bool verbose) {
   }
 
   if (HasInput("sections")) {
-    if (IsConstantInput("sections")) {
-      TryGetInputValue("sections", &sections_);
-    } else {
+    if (!TryGetInputValue("sections", &sections_)) {
       Logger(verbose, 13) << "While input sections is not a constant tensor, "
                           << RequireOpset(13) << std::endl;
       return 13;
@@ -69,20 +72,8 @@ int32_t SplitMapper::GetMinOpsetVersion(bool verbose) {
   return 7;
 }
 
-void SplitMapper::Opset7() {
-  std::vector<TensorInfo> input_info;
-  std::vector<TensorInfo> output_info;
-  if (HasInput("X")) {
-    input_info = GetInput("X");
-  } else {
-    input_info = GetInput("x");
-  }
-  if (HasOutput("Out")) {
-    output_info = GetOutput("Out");
-  } else {
-    output_info = GetOutput("out");
-  }
-  int64_t axis = axis_;
+int64_t SplitMapper::GetAxis(int64_t rank) {
+  int64_t axis = axis_;  // old IR
   if (HasInput("axis") || HasInput("AxisTensor")) {
     if (in_pir_mode) {
       double value = 0;
@@ -98,37 +89,94 @@ void SplitMapper::Opset7() {
     }
   }
   if (axis < 0) {
-    axis += input_info[0].Rank();
+    axis += rank;
+    // input_info[0].Rank();
   }
-  Assert(!HasInput("SectionsTensorList"),
-         "[Paddle2ONNX](split) While SectionTensorList as input, requires "
-         "opset_version >= 13.");
-
+  return axis;
+}
+std::string SplitMapper::GetSections(int64_t dimension) {
+  std::string splits = "";
+  if (HasInput("SectionsTensorList")) {
+    auto info = GetInput("SectionsTensorList");
+    splits = helper_->ConcatIndices(info);
+  } else if (HasInput("sections")) {
+    auto info = GetInput("sections");
+    splits = helper_->ConcatIndices(info);
+  } else if (sections_.size() > 0) {
+    int sum_of_known_dim = 0;
+    for (size_t i = 0; i < sections_.size(); ++i) {
+      if (sections_[i] > 0) {
+        sum_of_known_dim += sections_[i];
+      }
+    }
+    for (size_t i = 0; i < sections_.size(); ++i) {
+      if (sections_[i] < 0) {
+        Assert(dimension > 0,
+               "Cannot convert split op, while there's -1 in sections and "
+               "cannot be infered by input shape.");
+        sections_[i] = dimension - sum_of_known_dim;
+      }
+    }
+    splits = helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, sections_);
+  } else if (HasAttr("num")) {
+    GetAttr("num", &num_);
+    Assert(dimension > 0,
+           "Cannot convert split op, due to target dimension is dynamic.");
+    int64_t each_part_size = dimension / num_;
+    sections_ = std::vector<int64_t>(num_, each_part_size);
+    sections_[num_ - 1] += dimension % num_;
+  }
+  return splits;
+}
+void SplitMapper::Opset7() {
+  std::vector<TensorInfo> input_info;
+  std::vector<TensorInfo> output_info;
+  if (HasInput("X")) {
+    input_info = GetInput("X");
+  } else {
+    input_info = GetInput("x");
+  }
+  if (HasOutput("Out")) {
+    output_info = GetOutput("Out");
+  } else {
+    output_info = GetOutput("out");
+  }
+  int64_t axis = GetAxis(input_info[0].Rank());
   if (HasInput("sections")) {
     TryGetInputValue("sections", &sections_);
+    Assert(sections_.size() > 0,
+           "While sections is empty, the conversion is not supported yet.");
   }
 
   if (sections_.size() > 0) {
-    int sum_of_kown_dim = 0;
+    int sum_of_known_dim = 0;
+    int cnt_of_unknown_dim = 0;
     for (size_t i = 0; i < sections_.size(); ++i) {
       if (sections_[i] > 0) {
-        sum_of_kown_dim += sections_[i];
+        sum_of_known_dim += sections_[i];
+      } else {
+        cnt_of_unknown_dim++;
       }
     }
+    Assert(
+        cnt_of_unknown_dim <= 1,
+        "Cannot convert split op, while there's more than 1 -1 in sections.");
     for (size_t i = 0; i < sections_.size(); ++i) {
       if (sections_[i] < 0) {
         Assert(
             input_info[0].shape[axis] > 0,
             "Cannot convert split op, while there's -1 in sections and cannot "
             "be infered by input shape.");
-        sections_[i] = input_info[0].shape[axis] - sum_of_kown_dim;
+        sections_[i] = input_info[0].shape[axis] - sum_of_known_dim;
       }
     }
-  } else {
+  } else if (HasAttr("num")) {
     GetAttr("num", &num_);
     int64_t each_part_size = input_info[0].shape[axis] / num_;
     sections_ = std::vector<int64_t>(num_, each_part_size);
     sections_[num_ - 1] += input_info[0].shape[axis] % num_;
+  } else {
+    Assert(false, "Split op must have sections or num attribute.");
   }
 
   std::vector<std::string> output_names(output_info.size());
@@ -153,56 +201,8 @@ void SplitMapper::Opset13() {
     output_info = GetOutput("out");
   }
 
-  int64_t axis = axis_;
-  if (HasInput("axis") || HasInput("AxisTensor")) {
-    if (in_pir_mode) {
-      double value = 0;
-      std::string attr_name = "AxisTensor";
-      if (HasInput("axis")) attr_name = "axis";
-      TryGetInputValue(attr_name, &value);
-      axis = (int64_t)value;
-    } else {
-      std::vector<int64_t> value;
-      Assert(TryGetInputValue("AxisTensor", &value),
-             "[Paddle2ONNX](split) Cannot get constant value from AxisTensor.");
-      axis = value[0];
-    }
-  }
-  if (axis < 0) {
-    axis += input_info[0].Rank();
-  }
-
-  std::string splits = "";
-  if (HasInput("SectionsTensorList")) {
-    auto info = GetInput("SectionsTensorList");
-    splits = helper_->ConcatIndices(info);
-  } else if (sections_.size() > 0 || HasInput("sections")) {
-    if (HasInput("sections")) {
-      TryGetInputValue("sections", &sections_);
-    }
-    int sum_of_kown_dim = 0;
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] > 0) {
-        sum_of_kown_dim += sections_[i];
-      }
-    }
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] < 0) {
-        Assert(input_info[0].shape[axis] > 0,
-               "Cannot convert split op, while there's -1 in sections and "
-               "cannot be infered by input shape.");
-        sections_[i] = input_info[0].shape[axis] - sum_of_kown_dim;
-      }
-    }
-    splits = helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, sections_);
-  } else {
-    if (HasAttr("num")) {
-      GetAttr("num", &num_);
-      int64_t each_part_size = input_info[0].shape[axis] / num_;
-      sections_ = std::vector<int64_t>(num_, each_part_size);
-      sections_[num_ - 1] += input_info[0].shape[axis] % num_;
-    }
-  }
+  int64_t axis = GetAxis(input_info[0].Rank());
+  std::string splits = GetSections(input_info[0].shape[axis]);
 
   std::vector<std::string> output_names(output_info.size());
   for (size_t i = 0; i < output_info.size(); ++i) {
@@ -237,52 +237,8 @@ void SplitMapper::Opset18() {
     output_info = GetOutput("out");
   }
 
-  int64_t axis = axis_;
-  if (HasInput("axis") || HasInput("AxisTensor")) {
-    if (in_pir_mode) {
-      double value = 0;
-      std::string attr_name = "AxisTensor";
-      if (HasInput("axis")) attr_name = "axis";
-      TryGetInputValue(attr_name, &value);
-      axis = (int64_t)value;
-    } else {
-      std::vector<int64_t> value;
-      Assert(TryGetInputValue("AxisTensor", &value),
-             "[Paddle2ONNX](split) Cannot get constant value from AxisTensor.");
-      axis = value[0];
-    }
-  }
-  if (axis < 0) {
-    axis += input_info[0].Rank();
-  }
-  // sections attribute
-  std::string splits = "";
-  if (HasInput("sections") || HasInput("SectionsTensorList")) {
-    if (in_pir_mode) {
-      auto info = GetInput("sections");
-      // splits = helper_->ConcatIndices(info);
-      splits = info[0].name;
-    } else {
-      auto info = GetInput("SectionsTensorList");
-      splits = helper_->ConcatIndices(info);
-    }
-  } else if (sections_.size() > 0) {
-    int sum_of_kown_dim = 0;
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] > 0) {
-        sum_of_kown_dim += sections_[i];
-      }
-    }
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] < 0) {
-        Assert(input_info[0].shape[axis] > 0,
-               "Cannot convert split op, while there's -1 in sections and "
-               "cannot be infered by input shape.");
-        sections_[i] = input_info[0].shape[axis] - sum_of_kown_dim;
-      }
-    }
-    splits = helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, sections_);
-  }
+  int64_t axis = GetAxis(input_info[0].Rank());
+  std::string splits = GetSections(input_info[0].shape[axis]);
 
   std::vector<std::string> output_names(output_info.size());
   for (size_t i = 0; i < output_info.size(); ++i) {
@@ -292,19 +248,15 @@ void SplitMapper::Opset18() {
     auto node =
         helper_->MakeNode("Split", {input_info[0].name, splits}, output_names);
     AddAttribute(node, "axis", axis);
-    return;
+  } else {
+    int64_t num = input_info[0].shape[axis];  // default
+    if (HasAttr("num")) {
+      GetAttr("num", &num);
+    }
+    auto node = helper_->MakeNode("Split", {input_info[0].name}, output_names);
+    AddAttribute(node, "axis", axis);
+    AddAttribute(node, "num_outputs", num);
   }
-  // [num] attribute -> [split] input
-  int64_t num = input_info[0].shape[axis];  // default
-  if (HasAttr("num")) {
-    GetAttr("num", &num);
-  }
-  // Question: Why do we need to call helper->Split() instead of
-  // helper->MakeNode("Split")? Answer: Split-18 requires either a split input
-  // or the num_ouputs attribute. Here we choose to add split input.
-  int64_t each_part_size = input_info[0].shape[axis] / num;
-  std::vector<int64_t> splits_size = std::vector<int64_t>(num, each_part_size);
-  helper_->Split(input_info[0].name, output_names, splits_size, axis);
 }
 
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/split.cc
+++ b/paddle2onnx/mapper/tensor/split.cc
@@ -73,7 +73,7 @@ int32_t SplitMapper::GetMinOpsetVersion(bool verbose) {
 }
 
 int64_t SplitMapper::GetAxis(int64_t rank) {
-  int64_t axis = axis_;  // old IR
+  int64_t axis = axis_;  // Old IR
   if (HasInput("axis") || HasInput("AxisTensor")) {
     if (in_pir_mode) {
       double value = 0;
@@ -90,10 +90,10 @@ int64_t SplitMapper::GetAxis(int64_t rank) {
   }
   if (axis < 0) {
     axis += rank;
-    // input_info[0].Rank();
   }
   return axis;
 }
+
 std::string SplitMapper::GetSections(int64_t dimension) {
   std::string splits = "";
   if (HasInput("SectionsTensorList")) {
@@ -102,20 +102,7 @@ std::string SplitMapper::GetSections(int64_t dimension) {
   } else if (sections_.size() > 0 ||
              (HasInput("sections") &&
               TryGetInputValue("sections", &sections_))) {
-    int sum_of_known_dim = 0;
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] > 0) {
-        sum_of_known_dim += sections_[i];
-      }
-    }
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] < 0) {
-        Assert(dimension > 0,
-               "Cannot convert split op, while there's -1 in sections and "
-               "cannot be infered by input shape.");
-        sections_[i] = dimension - sum_of_known_dim;
-      }
-    }
+    ProcessSections(dimension);
     splits = helper_->Constant(ONNX_NAMESPACE::TensorProto::INT64, sections_);
   } else if (HasInput("sections")) {
     auto info = GetInput("sections");
@@ -130,6 +117,29 @@ std::string SplitMapper::GetSections(int64_t dimension) {
   }
   return splits;
 }
+
+void SplitMapper::ProcessSections(int64_t dimension) {
+  int sum_of_known_dim = 0;
+  int cnt_of_unknown_dim = 0;
+  for (size_t i = 0; i < sections_.size(); ++i) {
+    if (sections_[i] > 0) {
+      sum_of_known_dim += sections_[i];
+    } else {
+      cnt_of_unknown_dim++;
+    }
+  }
+  Assert(cnt_of_unknown_dim <= 1,
+         "Cannot convert split op, while there's more than 1 -1 in sections.");
+  for (size_t i = 0; i < sections_.size(); ++i) {
+    if (sections_[i] < 0) {
+      Assert(dimension > 0,
+             "Cannot convert split op, while there's -1 in sections and cannot "
+             "be infered by input shape.");
+      sections_[i] = dimension - sum_of_known_dim;
+    }
+  }
+}
+
 void SplitMapper::Opset7() {
   std::vector<TensorInfo> input_info;
   std::vector<TensorInfo> output_info;
@@ -151,27 +161,7 @@ void SplitMapper::Opset7() {
   }
 
   if (sections_.size() > 0) {
-    int sum_of_known_dim = 0;
-    int cnt_of_unknown_dim = 0;
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] > 0) {
-        sum_of_known_dim += sections_[i];
-      } else {
-        cnt_of_unknown_dim++;
-      }
-    }
-    Assert(
-        cnt_of_unknown_dim <= 1,
-        "Cannot convert split op, while there's more than 1 -1 in sections.");
-    for (size_t i = 0; i < sections_.size(); ++i) {
-      if (sections_[i] < 0) {
-        Assert(
-            input_info[0].shape[axis] > 0,
-            "Cannot convert split op, while there's -1 in sections and cannot "
-            "be infered by input shape.");
-        sections_[i] = input_info[0].shape[axis] - sum_of_known_dim;
-      }
-    }
+    ProcessSections(input_info[0].shape[axis]);
   } else if (HasAttr("num")) {
     GetAttr("num", &num_);
     int64_t each_part_size = input_info[0].shape[axis] / num_;

--- a/paddle2onnx/mapper/tensor/split.h
+++ b/paddle2onnx/mapper/tensor/split.h
@@ -41,6 +41,8 @@ class SplitMapper : public Mapper {
   }
 
   int32_t GetMinOpsetVersion(bool verbose) override;
+  int64_t GetAxis(int64_t rank);
+  std::string GetSections(int64_t dimension);
   void Opset7() override;
   void Opset13() override;
   void Opset18() override;

--- a/paddle2onnx/mapper/tensor/split.h
+++ b/paddle2onnx/mapper/tensor/split.h
@@ -43,6 +43,7 @@ class SplitMapper : public Mapper {
   int32_t GetMinOpsetVersion(bool verbose) override;
   int64_t GetAxis(int64_t rank);
   std::string GetSections(int64_t dimension);
+  void ProcessSections(int64_t dimension);
   void Opset7() override;
   void Opset13() override;
   void Opset18() override;

--- a/paddle2onnx/utils/utils.h
+++ b/paddle2onnx/utils/utils.h
@@ -23,7 +23,7 @@ namespace paddle2onnx {
 
 inline void Assert(bool condition, const std::string& message) {
   if (!condition) {
-    fprintf(stderr, "[ERROR] %s\n", message.c_str());
+    fprintf(stderr, "[ERROR][Paddle2ONNX] %s\n", message.c_str());
     std::abort();
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ classifiers = [
 license = {text = "Apache License v2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "polygraphy>=0.49.20",
     "onnx>=1.16",
+    "onnxoptimizer==0.3.13",
+    "polygraphy>=0.49.20",
 ]
 
 [project.scripts]

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -514,7 +514,7 @@ class APIOnnx(object):
                     "",  # calibration_file
                     "",  # external_file
                     False,  # export_fp16_model
-                    "onnxoptimizer",  # optimize_tool
+                    "None",  # optimize_tool
                 )
                 with open(
                     os.path.join(self.name, self.name + "_" + str(v) + ".onnx"), "wb"

--- a/tests/onnxbase.py
+++ b/tests/onnxbase.py
@@ -514,7 +514,7 @@ class APIOnnx(object):
                     "",  # calibration_file
                     "",  # external_file
                     False,  # export_fp16_model
-                    False,  # enable polygraphy
+                    "onnxoptimizer",  # optimize_tool
                 )
                 with open(
                     os.path.join(self.name, self.name + "_" + str(v) + ".onnx"), "wb"

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -50,6 +50,7 @@ set ignore=!ignore! test_auto_scan_conv3d.py
 set ignore=!ignore! test_auto_scan_grid_sampler.py
 set ignore=!ignore! test_auto_scan_gaussian_random.py
 set ignore=!ignore! test_auto_scan_partial_ops.py
+set ignore=!ignore! test_auto_scan_pool_avg_ops.py
 REM window ci bug, need to be fixed
 set ignore=!ignore! test_Conv2D_Dropout.py
 REM Initialize bug count


### PR DESCRIPTION
1.  Fix the issue with split op, which encountered during the conversion of model `Co-Deformable-DETR-Swin-T` and `Co-Deformable-DETR-R50` .
2. Fix the issue with onnx optimizer `polygraphy`:  Issues arise during inference with ORT when using an ONNX model optimized with `polygraphy`,  including `ShiTuV2_rec_CLIP_vit_base` and `Mask-RT-DETR-H`.