### PR TITLE
[Debug] Record debug info for exporting op

### DIFF
--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -749,6 +749,8 @@ void ModelExporter::ExportOp(const PaddlePirParser& pir_parser,
                              int64_t op_id,
                              bool if_in_subblock,
                              bool verbose) {
+  P2OLogger(verbose_) << "Start export " << op->name()
+                      << ", op_id: " << op->id() << std::endl;
   auto mapper =
       MapperHelper::Get()->CreateMapper(convert_pir_op_name(op->name()),
                                         pir_parser,
@@ -758,6 +760,8 @@ void ModelExporter::ExportOp(const PaddlePirParser& pir_parser,
   mapper->deploy_backend = deploy_backend_;
   mapper->Run();
   delete mapper;
+  P2OLogger(verbose_) << "Finish export " << op->name()
+                      << ", op_id: " << op->id() << std::endl;
 }
 
 void ModelExporter::CovertCustomOps(const PaddleParser& parser,


### PR DESCRIPTION
Record exporting info to debug quickly.
It is recommended to set `FLAGS_print_ir=1` along with the `--enable_verbose` option.