### PR TITLE
Limit package version of `onnx`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 license = {text = "Apache License v2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "onnx>=1.16",
+    "onnx>=1.16,<=1.17.0",
     "onnxoptimizer==0.3.13; python_version < '3.12'",
     "polygraphy>=0.49.20",
 ]


### PR DESCRIPTION
限制`onnx<=1.17.0`，因为集成了`polygraphy` ，在进行常量折叠时会升级ir version为当前环境中`onnx`支持的最高版本，`onnx>=1.18.0` 时支持ir version 11, 而`onnxruntime<=1.22.0`时 最高支持ir version 10，会导致使用ORT推理失败，因此需要限制`onnx<=1.17.0` .
如果必须使用`onnx>=1.18.0` ，可以通过添加`--optimize_tool=None`选项跳过`polygraphy`