### PR TITLE
Fix the issue with full_with_tensor, sum

### DIFF
--- a/paddle2onnx/convert.py
+++ b/paddle2onnx/convert.py
@@ -170,6 +170,9 @@ def export(
                     [inference_program, feed_target_names, fetch_targets] = (
                         paddle.static.load_inference_model(model_file_path, exe)
                     )
+                if verbose:
+                    logging.info("The original inference program is:\n")
+                    logging.info(f"{inference_program}\n\n")
                 program = paddle.pir.translate_to_pir(inference_program.desc)
                 # TODO(wangmingkai02): Do we need to call load_parameter(program) here?
                 load_parameter(program)

--- a/paddle2onnx/mapper/tensor/full_with_tensor.cc
+++ b/paddle2onnx/mapper/tensor/full_with_tensor.cc
@@ -33,6 +33,8 @@ void FullWithTensorMapper::Opset8() {
 
   if (shape_info[0].Rank() == 0) {
     shape = helper_->Reshape(shape, {1});
+  } else if (shape_info[0].Rank() > 1) {
+    shape = helper_->Reshape(shape, {-1});
   }
 
   auto expand_node = helper_->MakeNode("Expand", {value_info[0].name, shape});

--- a/paddle2onnx/mapper/tensor/reduce_sum.cc
+++ b/paddle2onnx/mapper/tensor/reduce_sum.cc
@@ -25,6 +25,7 @@ int32_t ReduceMapperSum::GetMinOpsetVersion(bool verbose) {
 }
 
 void ReduceMapperSum::Opset13() {
+  auto out_info = GetOutput("Out");
   auto axis_name_ = "dim";
   GetAttr("keep_dim", &keep_dim_);
   if (!in_pir_mode) {
@@ -39,7 +40,10 @@ void ReduceMapperSum::Opset13() {
     }
   } else {
     TryGetInputValue("axis", &dim_);
-    if (dim_.size() == 0) {
+    // Note: This is a temporary solution. It's needed to be fixed in
+    // ProgramTranslator.
+    if (dim_.size() == 0 || out_info[0].Rank() == 0 ||
+        (out_info[0].Rank() == 1 && out_info[0].shape[0] == 1)) {
       reduce_all_ = true;
     } else {
       reduce_all_ = false;
@@ -79,7 +83,6 @@ void ReduceMapperSum::Opset13() {
   if (!keep_dim_ && reduce_all_axes) {
     out_node_name = helper_->Reshape(out_node_name, {-1});
   }
-  auto out_info = GetOutput("Out");
   helper_->AutoCast(out_node_name, out_info[0].name, x_tpye, out_info[0].dtype);
 }
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/scale.cc
+++ b/paddle2onnx/mapper/tensor/scale.cc
@@ -16,77 +16,31 @@
 #include <vector>
 
 namespace paddle2onnx {
-
-REGISTER_MAPPER(scale, ScaleMapper)
 REGISTER_PIR_MAPPER(scale, ScaleMapper)
 
 void ScaleMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Out");
-  bool has_scale_tensor = HasInput("ScaleTensor");
-  bool is_scale_1 = ((scale_ - 1.0) < 1e-06 && (scale_ - 1.0) > -1e-06);
-  bool is_bias_0 = (bias_ < 1e-06 && bias_ > -1e-06);
-
-  if (!has_scale_tensor && is_scale_1 && is_bias_0) {
-    helper_->MakeNode("Identity", {input_info[0].name}, {output_info[0].name});
+  auto scale_info = GetInput("ScaleTensor");
+  auto input = helper_->AutoCast(
+      input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
+  std::string out = input;
+  if (bias_after_scale_) {
+    auto scale = helper_->AutoCast(
+        scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
+    out = helper_->MakeNode("Mul", {out, scale})->output(0);
+    auto bias =
+        helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, bias_);
+    out = helper_->MakeNode("Add", {out, bias})->output(0);
   } else {
-    auto input = helper_->AutoCast(
-        input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
-    std::string out = input;
-    if (bias_after_scale_) {
-      if (!is_scale_1 || has_scale_tensor) {
-        if (has_scale_tensor) {
-          auto scale_info = GetInput("ScaleTensor");
-          auto scale = helper_->AutoCast(
-              scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
-          out = helper_->MakeNode("Mul", {out, scale})->output(0);
-        } else {
-          auto scale =
-              helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, scale_);
-          out = helper_->MakeNode("Mul", {out, scale})->output(0);
-        }
-      }
-      if (!is_bias_0) {
-        auto bias =
-            helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, bias_);
-        out = helper_->MakeNode("Add", {out, bias})->output(0);
-      }
-    } else {
-      if (!is_bias_0) {
-        auto bias =
-            helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, bias_);
-        out = helper_->MakeNode("Add", {out, bias})->output(0);
-      }
-      if (!is_scale_1 || has_scale_tensor) {
-        if (has_scale_tensor) {
-          auto scale_info = GetInput("ScaleTensor");
-          auto scale = helper_->AutoCast(
-              scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
-          out = helper_->MakeNode("Mul", {out, scale})->output(0);
-        } else {
-          auto scale =
-              helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, scale_);
-          out = helper_->MakeNode("Mul", {out, scale})->output(0);
-        }
-      }
-    }
-    int32_t cnt = 0;
-    for (auto i : output_info[0].shape) {
-      if (i == -1) cnt++;
-    }
-    std::string reshape_out;
-    if (cnt > 1) {
-      auto input_shape =
-          helper_->MakeNode("Shape", {input_info[0].name})->output(0);
-      reshape_out = helper_->MakeNode("Reshape", {out, input_shape})->output(0);
-    } else {
-      reshape_out = helper_->Reshape(out, output_info[0].shape);
-    }
-
-    helper_->AutoCast(reshape_out,
-                      output_info[0].name,
-                      P2ODataType::FP32,
-                      output_info[0].dtype);
+    auto bias =
+        helper_->Constant({}, ONNX_NAMESPACE::TensorProto::FLOAT, bias_);
+    out = helper_->MakeNode("Add", {out, bias})->output(0);
+    auto scale = helper_->AutoCast(
+        scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
+    out = helper_->MakeNode("Mul", {out, scale})->output(0);
   }
+  helper_->AutoCast(
+      out, output_info[0].name, P2ODataType::FP32, output_info[0].dtype);
 }
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/tensor/scale.h
+++ b/paddle2onnx/mapper/tensor/scale.h
@@ -20,21 +20,11 @@ namespace paddle2onnx {
 
 class ScaleMapper : public Mapper {
  public:
-  ScaleMapper(const PaddleParser& p,
-              OnnxHelper* helper,
-              int64_t block_id,
-              int64_t op_id)
-      : Mapper(p, helper, block_id, op_id) {
-    GetAttr("scale", &scale_);
-    GetAttr("bias", &bias_);
-    GetAttr("bias_after_scale", &bias_after_scale_);
-  }
-
   ScaleMapper(const PaddlePirParser& p,
               OnnxHelper* helper,
               int64_t op_id,
-              bool c)
-      : Mapper(p, helper, op_id, c) {
+              bool if_in_cf_block)
+      : Mapper(p, helper, op_id, if_in_cf_block) {
     GetAttr("bias", &bias_);
     GetAttr("bias_after_scale", &bias_after_scale_);
   }

--- a/tests/test_full_with_tensor.py
+++ b/tests/test_full_with_tensor.py
@@ -73,3 +73,18 @@ def test_full_with_tensor_2():
     obj = APIOnnx(op, "full_with_tensor", [8])
     obj.set_input_data("input_data", paddle.to_tensor([2, 3]), paddle.to_tensor(3))
     obj.run()
+
+
+@_test_only_pir
+def test_full_with_tensor_3():
+    """
+    op version: 8
+    """
+    op = Net2()
+    op.eval()
+    # net, name, ver_list, delta=1e-6, rtol=1e-5
+    obj = APIOnnx(op, "full_with_tensor", [8])
+    obj.set_input_data(
+        "input_data", paddle.ones(shape=[3, 2]).astype("int32"), paddle.to_tensor(3)
+    )
+    obj.run()


### PR DESCRIPTION
1. 修复`full_with_tensor`
    * 支持shape维度大于1的场景
2. 修复`sum`
    * 修改判断是否对全部维度规约的判断规则
 #### 问题2补充
* 背景：使用ProgramTranslator转化时，`reduce_sum` 算子指定了要规约的维度`dim` ，但同时设置了` reduce_all = True`，转化时只根据`dim` 进行转化，而`dim` 中并不包含所有的维度，Paddle2ONNX中使用转化得到的`sum` 算子的`IntArray axis` 判断是否`reduce_all`，造成判断错误，导致shape不匹配。

```
# 旧IR Program中的reduce_sum算子
{Out=['sum_20.tmp_0']} = reduce_sum(inputs={X=['embedding_0.w_0']}, dim = [0], in_dtype = -1, keep_dim = False, op_device = , op_namescope = /, op_role = 0, op_role_var = [], out_dtype = -1, reduce_all = True)
# PIR Program中的reduce_sum算子
(%4086) = "pd_op.sum" (%486, %4085) {dtype:Undefined,keepdim:false,persistable:[false],stop_gradient:[false]} : (tensor<14x256xf32>, tensor<1xi64>) -> tensor<1xf32>
