### PR TITLE
Update local compilation docs

### DIFF
--- a/docs/en/compile_local.md
+++ b/docs/en/compile_local.md
@@ -22,8 +22,19 @@ make install
 # set the library to environment
 export PATH=${PWD}/installed_protobuf_lib/bin:${PATH}
 ```
+### Alternatively:
 
-### 1.2 Install Protobuf
+Install Protobuf via apt (Linux):
+```bash
+sudo apt install protobuf-compiler
+```
+
+Install Protobuf via homebrew (Mac):
+```bash
+brew install protobuf
+```
+
+### 1.2 Install PaddlePaddle
 
 ```bash
 python -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
@@ -45,12 +56,17 @@ If you are developing the Paddle2ONNX project locally, you can use `pip install 
 ## 2 Install on Windows
 
 **Note that the prerequisite for compiling and installing Windows is that Visual Studio 2019 is already installed in the system**
+### 2.1 Install Visual Studio 16 2019
+1. Download Visual Studio 16 2019 from [this link](https://download.visualstudio.microsoft.com/download/pr/e7ffa30b-43a5-4afc-bf2a-2e3656a842e4/60b26131ac7b8c59f734a1e0c32cc9dc/vs_community.exe) and run `vs_community.exe`.
+2. Under the **Workloads** tab, select the checkbox for **Desktop development with C++**.
+   - Note: Under Installation Details > Desktop Development with C++ > Optional: **Live Share** and **Intellicode** are unnecessary, feel free to uncheck these boxes.
+3. Click **Install**
 
-### 2.1 Open Visual Studio Command Prompt
+### 2.2 Open Visual Studio Command Prompt
 
 In the system menu, find **x64 Native Tools Command Prompt for VS 2019** and open it.
 
-### 2.2 Install Protobuf
+### 2.3 Install Protobuf
 
 Note that the `-DCMAKE_INSTALL_PREFIX` in the following cmake command specifies your actual set path.
 
@@ -67,7 +83,7 @@ cmake --build . --config Release --target install
 set PATH=%CD%\protobuf_install\bin;%PATH%
 ```
 
-### 2.3 Install Paddle2ONNX
+### 2.4 Install Paddle2ONNX
 
 ```bash
 git clone https://github.com/PaddlePaddle/Paddle2ONNX.git

--- a/docs/en/op_list.md
+++ b/docs/en/op_list.md
@@ -61,6 +61,8 @@ All supported PaddlePaddle operators are listed as below,
 - hard_shrink
 - hard_sigmoid
 - hard_swish
+- index_put
+- index_select
 - layer_norm
 - leaky_relu
 - less_equal
@@ -110,6 +112,7 @@ All supported PaddlePaddle operators are listed as below,
 - round
 - rsqrt
 - scale
+- scatter
 - selu
 - set_value
 - shape

--- a/docs/zh/compile_local.md
+++ b/docs/zh/compile_local.md
@@ -1,13 +1,13 @@
 # 如何在本地编译并安装 Paddle2ONNX
 
-Paddle2ONNX 的编译安装至少需要确保环境满足以下需求：
+Paddle2ONNX 的编译安装需要确保环境满足以下需求：
 
 - cmake >= 3.16.0
 - protobuf == 21.12
 
-## 在 Linux/Mac 下编译并安装
+## 1 在 Linux/Mac 下安装
 
-### 安装 Protobuf
+### 1.1 安装 Protobuf
 
 ```bash
 git clone https://github.com/protocolbuffers/protobuf.git
@@ -19,27 +19,31 @@ cmake ../cmake -DCMAKE_INSTALL_PREFIX=`pwd`/installed_protobuf_lib -Dprotobuf_BU
 make -j
 make install
 
-# 将编译目录加入环境变量
+# 将库路径添加到环境变量
 export PATH=${PWD}/installed_protobuf_lib/bin:${PATH}
 ```
-### 或者
 
-安装 Protobuf (Linux):
+### 或者：
+
+通过 apt 安装 Protobuf (Linux):
+
 ```bash
 sudo apt install protobuf-compiler
 ```
 
-安装 Protobuf (Mac):
+通过 homebrew 安装 Protobuf (Mac):
+
 ```bash
 brew install protobuf
 ```
 
-### 安装PaddlePaddle
+### 1.2 安装 PaddlePaddle
+
 ```bash
 python -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/
 ```
 
-### 安装Paddle2ONNX
+### 1.3 安装 Paddle2ONNX
 
 ```bash
 git clone https://github.com/PaddlePaddle/Paddle2ONNX.git
@@ -50,19 +54,26 @@ python -m build
 pip install dist/*.whl
 ```
 
-如果你是在本地开发　Paddle2ONNX 项目，推荐使用 `pip install -e .` 命令，以 editable mode 来安装。
+如果你是在本地开发 Paddle2ONNX 项目，可以使用 `pip install -e .` 命令以可编辑模式安装。
 
-## Windows编译安装
+## 2 在 Windows 下安装
 
-注意Windows编译安装先验条件是系统中已安装好[Visual Studio 2019](https://download.visualstudio.microsoft.com/download/pr/e7ffa30b-43a5-4afc-bf2a-2e3656a842e4/60b26131ac7b8c59f734a1e0c32cc9dc/vs_community.exe)
+**注意，在 Windows 上编译安装的先决条件是系统已安装 Visual Studio 2019**
 
-### 打开VS命令行工具
+### 2.1 安装 Visual Studio 16 2019
 
-系统菜单中，找到**x64 Native Tools Command Prompt for VS 2019**打开
+1. 从[此链接](https://download.visualstudio.microsoft.com/download/pr/e7ffa30b-43a5-4afc-bf2a-2e3656a842e4/60b26131ac7b8c59f734a1e0c32cc9dc/vs_community.exe)下载 Visual Studio 16 2019 并运行 `vs_community.exe`。
+2. 在 **工作负载** 选项卡下，勾选 **使用 C++ 的桌面开发**。
+   - 注意：在安装详细信息 > 使用 C++ 的桌面开发 > 可选 中：**Live Share** 和 **Intellicode** 不是必需的，可以取消勾选。
+3. 点击 **安装**
 
-### 安装Protobuf
+### 2.2 打开 Visual Studio 命令提示符
 
-注意下面cmake命令中`-DCMAKE_INSTALL_PREFIX`指定为你实际设定的路径
+在系统菜单中，找到 **x64 Native Tools Command Prompt for VS 2019** 并打开。
+
+### 2.3 安装 Protobuf
+
+注意下面cmake命令中`-DCMAKE_INSTALL_PREFIX`指定为你实际设定的路径。
 
 ```bash
 git clone https://github.com/protocolbuffers/protobuf.git
@@ -73,11 +84,11 @@ mkdir build
 cd build
 cmake -G "Visual Studio 16 2019"  -DCMAKE_INSTALL_PREFIX=%CD%\protobuf_install -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_BUILD_EXAMPLES=OFF ..
 cmake --build . --config Release --target install
-# 设置环境变量
+# 将库设置到环境变量
 set PATH=%CD%\protobuf_install\bin;%PATH%
 ```
 
-### 安装Paddle2ONNX
+### 2.4 安装 Paddle2ONNX
 
 ```bash
 git clone https://github.com/PaddlePaddle/Paddle2ONNX.git

--- a/docs/zh/compile_local.md
+++ b/docs/zh/compile_local.md
@@ -22,6 +22,17 @@ make install
 # 将编译目录加入环境变量
 export PATH=${PWD}/installed_protobuf_lib/bin:${PATH}
 ```
+### 或者
+
+安装 Protobuf (Linux):
+```bash
+sudo apt install protobuf-compiler
+```
+
+安装 Protobuf (Mac):
+```bash
+brew install protobuf
+```
 
 ### 安装PaddlePaddle
 ```bash
@@ -43,7 +54,7 @@ pip install dist/*.whl
 
 ## Windows编译安装
 
-注意Windows编译安装先验条件是系统中已安装好Visual Studio 2019
+注意Windows编译安装先验条件是系统中已安装好[Visual Studio 2019](https://download.visualstudio.microsoft.com/download/pr/e7ffa30b-43a5-4afc-bf2a-2e3656a842e4/60b26131ac7b8c59f734a1e0c32cc9dc/vs_community.exe)
 
 ### 打开VS命令行工具
 

--- a/docs/zh/op_list.md
+++ b/docs/zh/op_list.md
@@ -61,6 +61,8 @@ All supported PaddlePaddle operators are listed as below,
 - hard_shrink
 - hard_sigmoid
 - hard_swish
+- index_put
+- index_select
 - layer_norm
 - leaky_relu
 - less_equal
@@ -110,6 +112,7 @@ All supported PaddlePaddle operators are listed as below,
 - round
 - rsqrt
 - scale
+- scatter
 - selu
 - set_value
 - shape


### PR DESCRIPTION
On Windows, Visual Studio 16 2019 is required for local compilation, but download links were hard to find since it's an old version. So I updated the documentation with the links I found to make it easier to set up for new contributors. I don't speak Chinese so if anyone would like to contribute a translation, that would be appreciated.