### PR TITLE
Fix missing optimize/fp16/external-data handling in PIR exporter

### DIFF
--- a/paddle2onnx/converter.cc
+++ b/paddle2onnx/converter.cc
@@ -98,7 +98,8 @@ PADDLE2ONNX_DECL bool Export(const char *model_filename,
                                 &calibration_str,
                                 external_file,
                                 save_external,
-                                export_fp16_model);
+                                export_fp16_model,
+                                disable_op_types);
     if (result.empty()) {
       P2OLogger(verbose) << "The exported ONNX model is invalid!" << std::endl;
       return false;

--- a/paddle2onnx/mapper/exporter.cc
+++ b/paddle2onnx/mapper/exporter.cc
@@ -1061,6 +1061,35 @@ std::string ModelExporter::Run(const PaddlePirParser& pir_parser,
                                  false,
                                  false);
   *onnx_model_.mutable_graph() = share_graph;
+
+  if (enable_optimize) {
+    onnx_model_ = Optimize(onnx_model_);
+  }
+
+  // convert fp32 model to fp16
+  if (export_fp16_model) {
+    P2OLogger(verbose) << "Convert FP32 ONNX model to FP16." << std::endl;
+    ConvertFp32ToFp16 convert(verbose);
+    convert.SetCustomOps(custom_ops);
+    convert.AddDisabledOpTypes(disable_fp16_op_types);
+    convert.Convert(&onnx_model_);
+  }
+
+  // save external data file for big model
+  std::string external_data_file;
+  if (onnx_model_.ByteSizeLong() > INT_MAX) {
+    if (external_file.empty()) {
+      external_data_file = "external_data";
+    } else {
+      external_data_file = external_file;
+    }
+  }
+
+  if (external_data_file.size()) {
+    SaveExternalData(
+        onnx_model_.mutable_graph(), external_data_file, save_external);
+  }
+
   if (enable_onnx_checker) {
     ONNXChecker(onnx_model_);
   }


### PR DESCRIPTION
## Summary

`ModelExporter::Run(const PaddlePirParser& ...)` currently diverges from the legacy `PaddleParser` path in a critical way: it builds the ONNX graph and immediately calls `SerializeToString(&out)` without applying:

- `enable_optimize`
- `export_fp16_model`
- big-model external-data handling via `SaveExternalData(...)`

For large PIR-exported models, that means Paddle2ONNX still tries to serialize a single in-memory `ModelProto`, which can exceed the protobuf 2GB limit and produce an unusable ONNX export.

This change brings the PIR exporter path back in line with the legacy exporter path by applying the same post-export steps before checker/serialization.

## What this patch changes

Inside `ModelExporter::Run(const PaddlePirParser& ...)`, this PR adds:

1. ONNX optimization when `enable_optimize` is enabled
2. FP16 conversion when `export_fp16_model` is enabled
3. external-data emission when `onnx_model_.ByteSizeLong() > INT_MAX`

The logic mirrors the existing implementation already used in `ModelExporter::Run(const PaddleParser& ...)`.

## Why this matters

Without this parity, PIR-exported large models can fail even though the codebase already has a supported external-data flow for large ONNX graphs.

In local validation with a real PIR-exported `uie-m-large` model:

- before this patch, export hit the >2GB protobuf limit and produced an unusable result
- after this patch, export produced a small `model.onnx` plus `model.onnx.data`
- the saved model passed path-based `onnx.checker.check_model(model_path)` validation

## Scope

This PR intentionally keeps the change minimal:

- no API changes
- no behavior changes for the legacy parser path
- no new flags or new codepaths beyond restoring parity for the PIR exporter

If helpful, I can follow up with a focused regression test once there is an agreed-upon large-model fixture strategy for CI.
