### PR TITLE
Fix: handle pir::DoubleAttribute in GetOpAttr(float*)

### DIFF
--- a/paddle2onnx/parser/pir_parser.cc
+++ b/paddle2onnx/parser/pir_parser.cc
@@ -686,8 +686,11 @@ void PaddlePirParser::GetOpAttr(const pir::Operation* op,
       found = true;
       if (pair.second.isa<pir::FloatAttribute>()) {
         *res = pair.second.dyn_cast<::pir::FloatAttribute>().data();
-        break;
+      } else if (pair.second.isa<pir::DoubleAttribute>()) {
+        *res = static_cast<float>(
+            pair.second.dyn_cast<::pir::DoubleAttribute>().data());
       }
+      break;
     }
   }
   PADDLE_ENFORCE_EQ(


### PR DESCRIPTION
PIR format stores float attributes like layer_norm epsilon as a_f64 (DoubleAttribute), but GetOpAttr(float*) only checked FloatAttribute. When epsilon was stored as double, *res was never written, leaving uninitialized stack garbage in the caller's epsilon_ variable.

This caused non-deterministic LayerNorm/GroupNorm/BatchNorm behavior: epsilon could be ~1e+27 (stack garbage), making Sqrt explode and Div produce near-zero output. Observed ~30% failure rate.

Fix: add DoubleAttribute branch with float cast.
Also fix: move break outside the if-else to avoid infinite loop when the attribute name matches but type does not.

Verified: all 10 dimensions (8-512) pass, diff < 1e-6, no non-determinism.

Fix #1646