### PR TITLE
Fix: add getusersitepackages() to cmake site-packages detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
   set(PYTHON_SITE_PACKAGES "")
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c
-            "import site; print(';'.join(site.getsitepackages()))"
+            "import site; sp = site.getsitepackages() + [site.getusersitepackages()]; print(';'.join(sp))"
     OUTPUT_VARIABLE SITE_PACKAGES_LIST
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   string(REPLACE ";" " " SITE_PACKAGES_LIST "${SITE_PACKAGES_LIST}")


### PR DESCRIPTION
On Ubuntu/Debian, site.getsitepackages() returns dist-packages (e.g. /usr/lib/python3/dist-packages), but the cmake regex check is SITE_PACKAGES MATCHES "site-packages", which never matches dist-packages.

Also, when paddle is installed via pip install --user, it goes to ~/.local/.../site-packages which is not returned by site.getsitepackages() — only by site.getusersitepackages().

Fix: query both system and user site-packages paths.

Fix #1648