### PR TITLE
fix: add PIR operator mappers for linear_v2, group_norm, layer_norm

### DIFF
--- a/paddle2onnx/mapper/nn/group_norm.cc
+++ b/paddle2onnx/mapper/nn/group_norm.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle2onnx/mapper/nn/group_norm.h"
-
 #include <cmath>
 #include <string>
 #include <vector>
@@ -23,6 +22,9 @@ REGISTER_MAPPER(group_norm, GroupNormMapper)
 REGISTER_PIR_MAPPER(group_norm, GroupNormMapper)
 
 int32_t GroupNormMapper::GetMinOpsetVersion(bool verbose) {
+  if (in_pir_mode) {
+    return 7;
+  }
   auto input_info = GetInput("X");
   if (input_info[0].Rank() != 4) {
     Error() << "Only support 4D-Tensor as input for GroupNorm" << std::endl;
@@ -32,46 +34,90 @@ int32_t GroupNormMapper::GetMinOpsetVersion(bool verbose) {
 }
 
 void GroupNormMapper::Opset7() {
-  auto input_info = GetInput("X");
-  auto output_info = GetOutput("Y");
+  std::string input_name, scale_name, bias_name, output_name;
+  bool has_scale = false, has_bias = false;
 
+  P2ODataType input_dtype;
+  if (in_pir_mode) {
+    auto x_info = GetInput(0);
+    input_name = x_info[0].name;
+    input_dtype = x_info[0].dtype;
+
+    auto s_info = GetInput(1);
+    has_scale = (s_info.size() > 0 && s_info[0].name.size() > 0);
+    if (has_scale) scale_name = s_info[0].name;
+
+    auto b_info = GetInput(2);
+    has_bias = (b_info.size() > 0 && b_info[0].name.size() > 0);
+    if (has_bias) bias_name = b_info[0].name;
+
+    auto out_info = GetOutput(0);
+    output_name = out_info[0].name;
+  } else {
+    auto input_info = GetInput("X");
+    input_name = input_info[0].name;
+    input_dtype = input_info[0].dtype;
+
+    if (HasInput("Scale")) {
+      scale_name = GetInput("Scale")[0].name;
+      has_scale = true;
+    }
+    if (HasInput("Bias")) {
+      bias_name = GetInput("Bias")[0].name;
+      has_bias = true;
+    }
+    auto output_info = GetOutput("Y");
+    output_name = output_info[0].name;
+  }
+
+  // PIR mode: 3D input [N, C, L] -> unsqueeze to 4D [N, C, L, 1]
+  if (in_pir_mode) {
+    input_name = helper_->Unsqueeze(input_name, {3});
+  }
+
+  // Reshape: [N, C, H, W] -> [N, groups, -1]
   std::vector<int64_t> shape_val = {0, groups_, -1};
   std::string shape =
       helper_->Constant(GetOnnxDtype(P2ODataType::INT64), shape_val);
+  auto reshape_in = helper_->MakeNode("Reshape", {input_name, shape});
 
-  auto reshape_input =
-      helper_->MakeNode("Reshape", {input_info[0].name, shape});
+  // InstanceNormalization with dummy scale/bias (size=groups)
+  // Real scale/bias applied afterwards.
+  // Use input dtype to avoid type mismatch when input is FP16/FP64.
+  auto onnx_dtype = GetOnnxDtype(input_dtype);
+  std::string dummy_scale =
+      helper_->Constant(onnx_dtype, std::vector<float>(groups_, 1.0));
+  std::string dummy_bias =
+      helper_->Constant(onnx_dtype, std::vector<float>(groups_, 0.0));
 
-  std::string scale_ = helper_->Constant(GetOnnxDtype(input_info[0].dtype),
-                                         std::vector<float>(groups_, 1.0));
+  auto inst_norm =
+      helper_->MakeNode("InstanceNormalization",
+                        {reshape_in->output(0), dummy_scale, dummy_bias});
+  AddAttribute(inst_norm, "epsilon", epsilon_);
 
-  std::string bias_ = helper_->Constant(GetOnnxDtype(input_info[0].dtype),
-                                        std::vector<float>(groups_, 0.0));
+  // Reshape back: [N, groups, -1] -> [N, C, H, W]
+  auto origin_shape = helper_->MakeNode("Shape", {input_name})->output(0);
+  auto reshape_out =
+      helper_->MakeNode("Reshape", {inst_norm->output(0), origin_shape});
 
-  auto reshaped_output = helper_->MakeNode(
-      "InstanceNormalization", {reshape_input->output(0), scale_, bias_});
-  AddAttribute(reshaped_output, "epsilon", epsilon_);
+  std::string output = reshape_out->output(0);
 
-  auto origin_shape = helper_->MakeNode("Shape", {input_info[0].name});
-
-  if (HasInput("Scale") && HasInput("Bias")) {
-    auto scale_info = GetInput("Scale");
-    auto bias_info = GetInput("Bias");
-    auto output = helper_->MakeNode(
-        "Reshape", {reshaped_output->output(0), origin_shape->output(0)});
-    std::string unsqueezed_scale =
-        helper_->Unsqueeze(scale_info[0].name, {1, 2});
-    std::string unsqueezed_bias = helper_->Unsqueeze(bias_info[0].name, {1, 2});
-    auto scale_output =
-        helper_->MakeNode("Mul", {output->output(0), unsqueezed_scale});
-    helper_->MakeNode("Add",
-                      {scale_output->output(0), unsqueezed_bias},
-                      {output_info[0].name});
-  } else {
-    helper_->MakeNode("Reshape",
-                      {reshaped_output->output(0), origin_shape->output(0)},
-                      {output_info[0].name});
+  // Apply real scale/bias
+  if (has_scale) {
+    std::string us_scale = helper_->Unsqueeze(scale_name, {1, 2});
+    output = helper_->MakeNode("Mul", {output, us_scale})->output(0);
   }
+  if (has_bias) {
+    std::string us_bias = helper_->Unsqueeze(bias_name, {1, 2});
+    output = helper_->MakeNode("Add", {output, us_bias})->output(0);
+  }
+
+  // Squeeze back to 3D if PIR mode
+  if (in_pir_mode) {
+    output = helper_->Squeeze(output, {3});
+  }
+
+  helper_->MakeNode("Identity", {output}, {output_name});
 }
 
 }  // namespace paddle2onnx

--- a/paddle2onnx/mapper/nn/layer_norm.cc
+++ b/paddle2onnx/mapper/nn/layer_norm.cc
@@ -26,6 +26,10 @@ REGISTER_PIR_MAPPER(layer_norm, LayerNormMapper)
 void LayerNormMapper::Opset17() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Y");
+  if (in_pir_mode) {
+    input_info = GetInput(0);
+    output_info = GetOutput(0);
+  }
 
   constexpr std::array<P2ODataType, 3> T = {
       P2ODataType::FP16, P2ODataType::FP32, P2ODataType::FP64};
@@ -41,18 +45,33 @@ void LayerNormMapper::Opset17() {
 
   bool has_input_Bias = HasInput("Bias");
   bool has_input_Scale = HasInput("Scale");
+  if (in_pir_mode) {
+    // PIR mode: inputs are positional (no named mapping in OpNameNormalizer)
+    // Input[0]=X, Input[1]=NormalizedShapeWeight, Input[2]=NormalizedShapeBias
+    auto s_info = GetInput(1);
+    has_input_Scale = (s_info.size() > 0 && s_info[0].name.size() > 0);
+    auto b_info = GetInput(2);
+    has_input_Bias = (b_info.size() > 0 && b_info[0].name.size() > 0);
+  }
+
+  // Helper to fetch scale/bias TensorInfo by name in legacy mode or by
+  // positional index in PIR mode.
+  auto get_tensor = [&](const std::string& name, int pir_idx) {
+    return in_pir_mode ? GetInput(pir_idx) : GetInput(name);
+  };
+
   if (has_input_Bias && has_input_Scale) {
-    auto scale_info = GetInput("Scale");
-    auto scale_name = scale_info[0].name;
-    auto scale_type = scale_info[0].dtype;
+    auto scale_info_vec = get_tensor("Scale", 1);
+    auto scale_name = scale_info_vec[0].name;
+    auto scale_type = scale_info_vec[0].dtype;
     if (std::find(T.begin(), T.end(), scale_type) == T.end()) {
       scale_name = helper_->AutoCast(scale_name, scale_type, P2ODataType::FP32);
       scale_type = P2ODataType::FP32;
     }
 
-    auto bias_info = GetInput("Bias");
-    auto bias_name = bias_info[0].name;
-    auto bias_type = bias_info[0].dtype;
+    auto bias_info_vec = get_tensor("Bias", 2);
+    auto bias_name = bias_info_vec[0].name;
+    auto bias_type = bias_info_vec[0].dtype;
     if (std::find(T.begin(), T.end(), bias_type) == T.end()) {
       bias_name = helper_->AutoCast(bias_name, bias_type, P2ODataType::FP32);
       bias_type = P2ODataType::FP32;
@@ -68,9 +87,9 @@ void LayerNormMapper::Opset17() {
   }
 
   if (has_input_Scale) {
-    auto scale_info = GetInput("Scale");
-    auto scale_name = scale_info[0].name;
-    auto scale_type = scale_info[0].dtype;
+    auto scale_info_vec = get_tensor("Scale", 1);
+    auto scale_name = scale_info_vec[0].name;
+    auto scale_type = scale_info_vec[0].dtype;
     if (std::find(T.begin(), T.end(), scale_type) == T.end()) {
       scale_name = helper_->AutoCast(scale_name, scale_type, P2ODataType::FP32);
       scale_type = P2ODataType::FP32;
@@ -89,9 +108,9 @@ void LayerNormMapper::Opset17() {
   }
 
   if (has_input_Bias) {
-    auto bias_info = GetInput("Bias");
-    auto bias_name = bias_info[0].name;
-    auto bias_type = bias_info[0].dtype;
+    auto bias_info_vec = get_tensor("Bias", 2);
+    auto bias_name = bias_info_vec[0].name;
+    auto bias_type = bias_info_vec[0].dtype;
     if (std::find(T.begin(), T.end(), bias_type) == T.end()) {
       bias_name = helper_->AutoCast(bias_name, bias_type, P2ODataType::FP32);
       bias_type = P2ODataType::FP32;
@@ -123,6 +142,10 @@ void LayerNormMapper::Opset17() {
 void LayerNormMapper::Opset7() {
   auto input_info = GetInput("X");
   auto output_info = GetOutput("Y");
+  if (in_pir_mode) {
+    input_info = GetInput(0);
+    output_info = GetOutput(0);
+  }
 
   std::string input_name = helper_->AutoCast(
       input_info[0].name, input_info[0].dtype, P2ODataType::FP32);
@@ -169,14 +192,28 @@ void LayerNormMapper::Opset7() {
 
   bool has_input_Bias = HasInput("Bias");
   bool has_input_Scale = HasInput("Scale");
+  // PIR mode: inputs are positional (no named mapping in OpNameNormalizer)
+  // Input[0]=X, Input[1]=NormalizedShapeWeight, Input[2]=NormalizedShapeBias
+  if (in_pir_mode) {
+    auto s_info = GetInput(1);
+    has_input_Scale = (s_info.size() > 0 && s_info[0].name.size() > 0);
+    auto b_info = GetInput(2);
+    has_input_Bias = (b_info.size() > 0 && b_info[0].name.size() > 0);
+  }
+
+  // Helper to fetch scale/bias TensorInfo by name in legacy mode or by
+  // positional index in PIR mode.
+  auto get_tensor = [&](const std::string& name, int pir_idx) {
+    return in_pir_mode ? GetInput(pir_idx) : GetInput(name);
+  };
 
   if (has_input_Bias && has_input_Scale) {
-    auto scale_info = GetInput("Scale");
-    auto bias_info = GetInput("Bias");
+    auto scale_info_vec = get_tensor("Scale", 1);
+    auto bias_info_vec = get_tensor("Bias", 2);
     std::string scale_name = helper_->AutoCast(
-        scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
+        scale_info_vec[0].name, scale_info_vec[0].dtype, P2ODataType::FP32);
     std::string bias_name = helper_->AutoCast(
-        bias_info[0].name, bias_info[0].dtype, P2ODataType::FP32);
+        bias_info_vec[0].name, bias_info_vec[0].dtype, P2ODataType::FP32);
     std::string scale_node = "";
     std::string bias_node = "";
     if (begin_norm_axis_ == input_shape.size() - 1) {
@@ -201,9 +238,9 @@ void LayerNormMapper::Opset7() {
     return;
   }
   if (has_input_Bias) {
-    auto bias_info = GetInput("Bias");
+    auto bias_info_vec = get_tensor("Bias", 2);
     std::string bias_name = helper_->AutoCast(
-        bias_info[0].name, bias_info[0].dtype, P2ODataType::FP32);
+        bias_info_vec[0].name, bias_info_vec[0].dtype, P2ODataType::FP32);
     std::string bias_node = "";
     if (begin_norm_axis_ == input_shape.size() - 1) {
       bias_node = helper_->Reshape(bias_name, {-1});
@@ -222,9 +259,9 @@ void LayerNormMapper::Opset7() {
     return;
   }
   if (has_input_Scale) {
-    auto scale_info = GetInput("Scale");
+    auto scale_info_vec = get_tensor("Scale", 1);
     std::string scale_name = helper_->AutoCast(
-        scale_info[0].name, scale_info[0].dtype, P2ODataType::FP32);
+        scale_info_vec[0].name, scale_info_vec[0].dtype, P2ODataType::FP32);
     std::string scale_node = "";
     if (begin_norm_axis_ == input_shape.size() - 1) {
       scale_node = helper_->Reshape(scale_name, {-1});

--- a/paddle2onnx/mapper/nn/linear_v2.cc
+++ b/paddle2onnx/mapper/nn/linear_v2.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle2onnx/mapper/nn/linear_v2.h"
+
+#include <string>
+#include <vector>
+
+namespace paddle2onnx {
+REGISTER_MAPPER(linear_v2, LinearV2Mapper)
+REGISTER_PIR_MAPPER(linear_v2, LinearV2Mapper)
+
+void LinearV2Mapper::Opset7() {
+  std::string input_x, input_w, input_b, output_name;
+  bool has_bias = false;
+
+  if (in_pir_mode) {
+    // PIR: positional inputs/outputs (no named mapping in OpNameNormalizer)
+    // Input[0]=X, Input[1]=Weight, Input[2]=Bias, Output[0]=Out
+    auto x_info = GetInput(0);
+    auto w_info = GetInput(1);
+    input_x = x_info[0].name;
+    input_w = w_info[0].name;
+
+    // Bias may be a null tensor in PIR - check if the name is valid
+    auto bias_info = GetInput(2);
+    has_bias = (bias_info.size() > 0 && bias_info[0].name.size() > 0);
+    if (has_bias) {
+      input_b = bias_info[0].name;
+    }
+
+    auto out_info = GetOutput(0);
+    output_name = out_info[0].name;
+  } else {
+    // OLD IR: named inputs/outputs
+    auto x_info = GetInput("X");
+    auto w_info = GetInput("Weight");
+    input_x = x_info[0].name;
+    input_w = w_info[0].name;
+
+    if (HasInput("Bias")) {
+      auto bias_info = GetInput("Bias");
+      has_bias = true;
+      input_b = bias_info[0].name;
+    }
+
+    auto out_info = GetOutput("Out");
+    output_name = out_info[0].name;
+  }
+
+  // In PIR format, linear_v2 stores weight in [in_dim, out_dim] layout.
+  // When transpose_weight=False (default): y = x @ w (direct matmul)
+  // When transpose_weight=True: need to transpose w first
+  if (transpose_weight_) {
+    // Transpose: [out_dim, in_dim] -> [in_dim, out_dim]
+    std::vector<int64_t> perm = {1, 0};
+    auto trans_node = helper_->MakeNode("Transpose", {input_w});
+    AddAttribute(trans_node, "perm", perm);
+    input_w = trans_node->output(0);
+  }
+
+  auto matmul = helper_->MakeNode("MatMul", {input_x, input_w});
+
+  if (has_bias) {
+    helper_->MakeNode("Add", {matmul->output(0), input_b}, {output_name});
+  } else {
+    helper_->MakeNode("Identity", {matmul->output(0)}, {output_name});
+  }
+}
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mapper/nn/linear_v2.h
+++ b/paddle2onnx/mapper/nn/linear_v2.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+
+#include "paddle2onnx/mapper/mapper.h"
+
+namespace paddle2onnx {
+
+class LinearV2Mapper : public Mapper {
+ public:
+  LinearV2Mapper(const PaddleParser& p,
+                 OnnxHelper* helper,
+                 int64_t block_id,
+                 int64_t op_id)
+      : Mapper(p, helper, block_id, op_id) {
+    GetAttr("transpose_weight", &transpose_weight_);
+  }
+
+  LinearV2Mapper(const PaddlePirParser& p,
+                 OnnxHelper* helper,
+                 int64_t op_id,
+                 bool c)
+      : Mapper(p, helper, op_id, c) {
+    GetAttr("transpose_weight", &transpose_weight_);
+  }
+
+  void Opset7() override;
+
+ private:
+  bool transpose_weight_ = false;
+};
+
+}  // namespace paddle2onnx

--- a/paddle2onnx/mappers_registry.h.in
+++ b/paddle2onnx/mappers_registry.h.in
@@ -29,10 +29,10 @@
 #define UNUSED __attribute__((unused))
 #endif
 
-#define USE_P2O_MAPPER(op_name, class_name)                           \
-  namespace paddle2onnx {                                             \
-    extern int Touch##op_name##class_name();                          \
-    int op_name##__registry__ UNUSED = Touch##op_name##class_name();  \
+#define USE_P2O_MAPPER(op_name, class_name)                        \
+  namespace paddle2onnx {                                          \
+  extern int Touch##op_name##class_name();                         \
+  int op_name##__registry__ UNUSED = Touch##op_name##class_name(); \
   }
 
 USE_P2O_MAPPER(quantize_linear, QuantizeLinearMapper)
@@ -40,6 +40,7 @@ USE_P2O_MAPPER(dequantize_linear, DequantizeLinearMapper)
 USE_P2O_MAPPER(batch_norm, BatchNormMapper)
 USE_P2O_MAPPER(dropout, DropoutMapper)
 USE_P2O_MAPPER(layer_norm, LayerNormMapper)
+USE_P2O_MAPPER(linear_v2, LinearV2Mapper)
 USE_P2O_MAPPER(rnn, RnnMapper)
 USE_P2O_MAPPER(softmax_with_cross_entropy, SoftmaxCrossEntropyLossMapper)
 USE_P2O_MAPPER(affine_channel, AffineChannelMapper)
@@ -218,5 +219,5 @@ USE_P2O_MAPPER(masked_select, MaskedSelectMapper)
 USE_P2O_MAPPER(uniform, UniformMapper)
 USE_P2O_MAPPER(conv3d_transpose, Conv3dTransposeMapper)
 USE_P2O_MAPPER(hardtanh, HardtanhMapper)
-#endif // WITH_PADDLE2ONNX_STATIC_INTERNAL_AT_COMPILING
-#endif // WITH_PADDLE2ONNX_STATIC_INTERNAL
+#endif  // WITH_PADDLE2ONNX_STATIC_INTERNAL_AT_COMPILING
+#endif  // WITH_PADDLE2ONNX_STATIC_INTERNAL

--- a/tests/test_auto_scan_linear.py
+++ b/tests/test_auto_scan_linear.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from auto_scan_test import OPConvertAutoScanTest, BaseNet
+import hypothesis.strategies as st
+import unittest
+import paddle
+from onnxbase import _test_with_pir
+
+
+class Net(BaseNet):
+    """
+    simple Net for nn.Linear.
+    """
+
+    def __init__(self, config=None):
+        super(Net, self).__init__(config)
+        in_features = self.config["in_features"]
+        out_features = self.config["out_features"]
+        self.fc = paddle.nn.Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias_attr=None if self.config["has_bias"] else False,
+        )
+
+    def forward(self, inputs):
+        x = self.fc(inputs)
+        return x
+
+
+class TestLinearConvert(OPConvertAutoScanTest):
+    """
+    Test nn.Linear export in PIR format.
+    """
+
+    def sample_convert_config(self, draw):
+        input_shape = draw(
+            st.lists(
+                st.integers(min_value=1, max_value=32),
+                min_size=2,
+                max_size=4,
+                unique=False,
+            )
+        )
+        in_features = draw(st.integers(min_value=16, max_value=256))
+        out_features = draw(st.integers(min_value=16, max_value=256))
+        input_shape[-1] = in_features
+
+        config = {
+            "in_features": in_features,
+            "out_features": out_features,
+            "has_bias": draw(st.booleans()),
+            "op_names": ["linear_v2"],
+            "test_data_shape": input_shape,
+            "use_gpu": True,
+            "min_opset_version": 7,
+            "max_opset_version": 15,
+        }
+
+        models = Net(config)
+
+        return (config, models)
+
+    @_test_with_pir
+    def test(self):
+        self.run_and_statis(max_examples=30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修复内容

1. **linear_v2**: 新增 PIR mapper，支持 PIR 格式的 Linear 算子导出
2. **group_norm**: 修复 PIR 模式下输入为 3D 的问题（Unsqueeze→处理→Squeeze）
3. **layer_norm**: 修复 PIR 模式下 `GetInput("Scale")` 应使用位置索引的问题

## 代码审查修复

- Opset7 + Opset17: PIR 模式下改用 `get_tensor` lambda 通过位置索引访问 Scale/Bias
- group_norm: 删除死代码 fallback block
- group_norm: InstanceNormalization dummy_scale 匹配输入 dtype（修复 FP32 硬编码）

## 其他

- `mappers_registry.h.in` 注册 PIR mapper
- 新增 `test_auto_scan_linear.py` CI 测试

Fix https://github.com/PaddlePaddle/Paddle2ONNX/issues/1644